### PR TITLE
feat: 5 launch blog posts for content pipeline [FROA-35]

### DIFF
--- a/content/blog/10-homebrew-monsters-for-your-dnd-campaign.mdx
+++ b/content/blog/10-homebrew-monsters-for-your-dnd-campaign.mdx
@@ -4,7 +4,7 @@ slug: "10-homebrew-monsters-for-your-dnd-campaign"
 excerpt: "Original monsters with full stat blocks — from a frost-revenants haunting glacial ruins to a corrupted elk deity of the northern woods. All tuned for 5e and designed to fit arctic or wilderness campaigns."
 coverImage: ""
 ogImage: "/images/blog/homebrew-monsters.jpg"
-publishedAt: "2026-05-15"
+publishedAt: "2026-05-12"
 tags: ["homebrew", "monsters", "stat-blocks", "dm-resources", "5e"]
 categories: ["Homebrew"]
 author: "Frozen Dice"

--- a/content/blog/10-homebrew-monsters-for-your-dnd-campaign.mdx
+++ b/content/blog/10-homebrew-monsters-for-your-dnd-campaign.mdx
@@ -1,0 +1,249 @@
+---
+title: "10 Homebrew D&D Monsters Ready to Drop Into Your Campaign"
+slug: "10-homebrew-monsters-for-your-dnd-campaign"
+excerpt: "Original monsters with full stat blocks — from a frost-revenants haunting glacial ruins to a corrupted elk deity of the northern woods. All tuned for 5e and designed to fit arctic or wilderness campaigns."
+coverImage: ""
+ogImage: "/images/blog/homebrew-monsters.jpg"
+publishedAt: "2026-05-15"
+tags: ["homebrew", "monsters", "stat-blocks", "dm-resources", "5e"]
+categories: ["Homebrew"]
+author: "Frozen Dice"
+---
+
+# 10 Homebrew D&D Monsters Ready to Drop Into Your Campaign
+
+The official Monster Manual is a masterpiece. It's also been on every DM's shelf since 2014, which means your players have read it too.
+
+Nothing surprises a veteran player like a monster they've never seen before. These ten homebrew creatures are designed for arctic and wilderness campaigns — specifically the kind of frost-haunted, Norse-flavored setting we explored in [building a frozen north campaign](/blog/building-a-frozen-north-campaign-setting). But they're modular: swap out the flavor text and they'll fit into any region.
+
+Each entry includes a complete 5e stat block and three adventure hooks.
+
+---
+
+## 1. Rimfrost Revenant
+
+*Medium undead, neutral evil*
+
+A warrior who died in a blizzard, denied burial rites by the cold. Rimfrost Revenants are identifiable by the frost that forms on any surface they touch and the sound of wind moaning through their empty chest.
+
+**Armor Class** 13 (natural armor)
+**Hit Points** 67 (9d8 + 27)
+**Speed** 30 ft.
+
+| STR | DEX | CON | INT | WIS | CHA |
+|-----|-----|-----|-----|-----|-----|
+| 18 (+4) | 10 (+0) | 16 (+3) | 9 (−1) | 10 (+0) | 14 (+2) |
+
+**Damage Immunities** cold, poison; bludgeoning, piercing, and slashing from nonmagical attacks
+**Condition Immunities** charmed, exhaustion, frightened, paralyzed, poisoned
+**Senses** darkvision 60 ft., passive Perception 10
+**Languages** the languages it knew in life
+**Challenge** 5 (1,800 XP)
+
+**Icebound Hatred.** The Rimfrost Revenant knows the direction and distance to any creature that dishonored its remains or denied it burial. It pursues that creature until one of them is destroyed.
+
+**Frost Aura.** Any creature that starts its turn within 5 feet of the Revenant takes 5 (1d10) cold damage.
+
+**Actions**
+
+***Multiattack.*** The Revenant makes two Frozen Touch attacks.
+
+***Frozen Touch.*** *Melee Weapon Attack:* +7 to hit, reach 5 ft., one target. *Hit:* 11 (2d6 + 4) bludgeoning damage plus 9 (2d8) cold damage. The target must succeed on a DC 14 Constitution saving throw or gain one level of exhaustion.
+
+***Glacial Howl (Recharge 5–6).*** The Revenant emits a freezing wail. Each creature within 30 feet that can hear it must succeed on a DC 13 Constitution saving throw or be paralyzed until the end of its next turn.
+
+**Adventure Hooks**
+- A merchant hired the party to retrieve goods from a shipwreck. The cargo includes a body that was robbed of burial jewelry.
+- A village is being haunted by something that freezes door handles and leaves frost-prints heading toward the graveyard.
+- The Revenant is hunting a party member's ancestor — and won't stop until it gets answers.
+
+---
+
+## 2. Kulde (The Hunger of Winter)
+
+*Large fiend (demon), chaotic evil*
+
+Kulde are predators born from the void between the stars that drift through arctic skies during deep winter. They appear as distorted shadows shaped like wolves, but their touch leaves frostbite on anything they brush against. They hunger for warmth — from fire, magic, or living bodies.
+
+**Armor Class** 14
+**Hit Points** 102 (12d10 + 36)
+**Speed** 50 ft., fly 50 ft. (hover)
+
+| STR | DEX | CON | INT | WIS | CHA |
+|-----|-----|-----|-----|-----|-----|
+| 20 (+5) | 18 (+4) | 16 (+3) | 8 (−1) | 13 (+1) | 12 (+1) |
+
+**Damage Resistances** fire, lightning; bludgeoning, piercing, and slashing from nonmagical attacks
+**Damage Immunities** cold, poison
+**Condition Immunities** charmed, frightened, poisoned
+**Senses** blindsight 60 ft., passive Perception 11
+**Languages** Abyssal
+**Challenge** 7 (2,900 XP)
+
+**Heat Hunger.** The Kulde can sense sources of heat, fire, or magical energy within 120 feet as if it had truesight.
+
+**Shadow Form.** The Kulde can move through creatures and objects as if they were difficult terrain. It takes 5 (1d10) force damage if it ends its turn inside an object.
+
+**Actions**
+
+***Multiattack.*** The Kulde makes one Void Bite and one Chill Claws attack.
+
+***Void Bite.*** *Melee Weapon Attack:* +8 to hit, reach 5 ft., one target. *Hit:* 14 (2d8 + 5) necrotic damage. The target's maximum hit points are reduced by the damage dealt until they finish a long rest.
+
+***Chill Claws.*** *Melee Weapon Attack:* +8 to hit, reach 5 ft., one target. *Hit:* 12 (2d6 + 5) cold damage and the target's speed is reduced by 10 feet until the end of its next turn.
+
+***Extinguish (1/Day).*** The Kulde targets all nonmagical flames within 60 feet of it. Each flame is snuffed out. Magical flames in the area require a DC 15 Dexterity saving throw from their caster or are also extinguished.
+
+**Adventure Hooks**
+- A hunting camp's fire went out in the night. Three hunters are missing. One survivor is describing a wolf-shaped shadow that walked through a wall.
+- A Kulde has bonded to an abandoned lighthouse, preventing anyone from lighting the flame. Ships have started running aground.
+- The party's warmth-generating magic items begin flickering — something is close, and it's drawn to their light.
+
+---
+
+## 3. Glassbone Elk (Corrupted Spirit)
+
+*Huge fey, neutral evil*
+
+Once revered as an aspect of the forest spirits, the Glassbone Elk has been twisted by dark ritual or ancient corruption. Its antlers are crystalline and razor-edged. Its body flickers at the edges like a lantern flame in wind. Druids and rangers who encounter one feel instinctive grief before the fear sets in.
+
+**Armor Class** 15 (natural armor)
+**Hit Points** 136 (16d12 + 32)
+**Speed** 60 ft.
+
+| STR | DEX | CON | INT | WIS | CHA |
+|-----|-----|-----|-----|-----|-----|
+| 22 (+6) | 14 (+2) | 14 (+2) | 10 (+0) | 16 (+3) | 18 (+4) |
+
+**Skills** Perception +7
+**Damage Resistances** bludgeoning, piercing, and slashing from nonmagical attacks not made with cold iron
+**Senses** darkvision 60 ft., passive Perception 17
+**Languages** Sylvan, Druidic (understands but rarely speaks)
+**Challenge** 9 (5,000 XP)
+
+**Aura of Sorrow.** Any creature that starts its turn within 30 feet of the Elk and can see it must succeed on a DC 15 Wisdom saving throw or become frightened until the start of its next turn.
+
+**Legendary Resistance (2/Day).** If the Elk fails a saving throw, it can choose to succeed instead.
+
+**Actions**
+
+***Multiattack.*** The Elk makes two Crystal Antler attacks.
+
+***Crystal Antler.*** *Melee Weapon Attack:* +10 to hit, reach 10 ft., one target. *Hit:* 19 (3d8 + 6) slashing damage plus 9 (2d8) psychic damage.
+
+***Trample.*** *Melee Weapon Attack:* +10 to hit, reach 5 ft., one creature. *Hit:* 22 (3d10 + 6) bludgeoning damage. If the target is Large or smaller, it must succeed on a DC 18 Strength saving throw or be knocked prone.
+
+***Shatter Antler (Recharge 5–6).*** The Elk shakes its head and shards of crystal spray outward. Each creature within 15 feet must make a DC 15 Dexterity saving throw, taking 28 (8d6) slashing damage on a failed save, or half as much on a successful one.
+
+**Adventure Hooks**
+- Druids are asking the party to put the Elk down — but one of the party's rangers recognizes it as the spirit her village once honored.
+- The Elk is the only creature that knows where an ancient grove used to stand. It can communicate but seems unwilling.
+- A cult claims that if the Elk is sacrificed during the next eclipse, it will restore something that was lost. What it will actually do is unclear.
+
+---
+
+## 4. Runestone Golem
+
+*Large construct, unaligned*
+
+Carved from glacier ice infused with ancient runes, Runestone Golems are bound to specific sites — usually burial mounds, sacred groves, or old fortifications. They do not pursue. They defend. And they are patient in ways that living things cannot be.
+
+**Armor Class** 17 (natural armor)
+**Hit Points** 178 (17d10 + 85)
+**Speed** 20 ft.
+
+| STR | DEX | CON | INT | WIS | CHA |
+|-----|-----|-----|-----|-----|-----|
+| 24 (+7) | 6 (−2) | 20 (+5) | 4 (−3) | 10 (+0) | 3 (−4) |
+
+**Damage Immunities** cold, poison, psychic; bludgeoning, piercing, and slashing from nonmagical attacks not made with adamantine
+**Condition Immunities** charmed, exhaustion, frightened, paralyzed, petrified, poisoned
+**Senses** darkvision 120 ft., passive Perception 10
+**Languages** understands the language of its creator but can't speak
+**Challenge** 10 (5,900 XP)
+
+**Immutable Form.** The Golem is immune to any spell or effect that would alter its form.
+
+**Runic Wards.** Spells of 3rd level or lower that target the Golem automatically fail. Higher-level spells succeed only if the caster succeeds on a DC 15 ability check using their spellcasting ability.
+
+**Threshold Bound.** The Golem cannot move more than 300 feet from the location it was created to protect. It knows if its ward has been crossed.
+
+**Actions**
+
+***Multiattack.*** The Golem makes two Rune Strike attacks.
+
+***Rune Strike.*** *Melee Weapon Attack:* +11 to hit, reach 5 ft., one target. *Hit:* 20 (3d8 + 7) bludgeoning damage plus 9 (2d8) force damage.
+
+***Cold Slam.*** *Melee Weapon Attack:* +11 to hit, reach 5 ft., one target. *Hit:* 25 (4d8 + 7) bludgeoning damage. If the target is Large or smaller, it must succeed on a DC 18 Strength saving throw or be restrained in ice until the end of its next turn.
+
+**Adventure Hooks**
+- The party needs to retrieve something from a burial mound. The runes say it was placed there willingly. The Golem was told to prevent removal.
+- The Golem has been dormant for centuries and has just reactivated. No one knows why, or what it's protecting.
+- An ancient cartographer wrote that the Golem knows the location of a lost city — but you have to phrase the question in old runes.
+
+---
+
+## 5. Frost Wight Berserker
+
+*Medium undead, chaotic evil*
+
+A standard wight is bad enough. The Frost Wight Berserker was a warrior in life who died in a state of battle-rage — and death didn't calm them down.
+
+**Armor Class** 14 (natural armor)
+**Hit Points** 85 (10d8 + 40)
+**Speed** 35 ft.
+
+| STR | DEX | CON | INT | WIS | CHA |
+|-----|-----|-----|-----|-----|-----|
+| 20 (+5) | 12 (+1) | 18 (+4) | 6 (−2) | 8 (−1) | 8 (−1) |
+
+**Damage Resistances** necrotic; bludgeoning, piercing, and slashing from nonmagical attacks
+**Damage Immunities** cold, poison
+**Condition Immunities** exhaustion, poisoned
+**Senses** darkvision 60 ft., passive Perception 9
+**Languages** understands languages it knew in life but can't speak
+**Challenge** 6 (2,300 XP)
+
+**Relentless (Recharges after a Short or Long Rest).** If the Berserker takes damage that would reduce it to 0 hit points, it is instead reduced to 1 hit point.
+
+**Reckless.** At the start of its turn, the Berserker can gain advantage on all melee attack rolls during that turn, but attack rolls against it have advantage until the start of its next turn.
+
+**Actions**
+
+***Multiattack.*** The Berserker makes three attacks: two with its Frost Greataxe and one Life Drain.
+
+***Frost Greataxe.*** *Melee Weapon Attack:* +8 to hit, reach 5 ft., one target. *Hit:* 14 (2d12 + 5) slashing damage plus 4 (1d8) cold damage.
+
+***Life Drain.*** *Melee Weapon Attack:* +8 to hit, reach 5 ft., one creature. *Hit:* 7 (1d6 + 4) necrotic damage. The target must succeed on a DC 14 Constitution saving throw or its maximum hit points are reduced by the damage dealt. This reduction lasts until the target finishes a long rest.
+
+**Adventure Hooks**
+- The party hears battle sounds from inside a barrow. The Berserker has been fighting the same battle for three hundred years.
+- A necromancer has been trying to bind Frost Wight Berserkers as soldiers. The bindings keep breaking.
+- The Berserker recognizes a party member as a descendant of its killer and won't attack anyone else.
+
+---
+
+## 6–10: Stat Block Summaries
+
+*(For use with the full descriptions in our [homebrew monsters supplement in the store](/store))*
+
+### 6. Tide Shade
+*Medium undead, neutral* — CR 4. A drowned spirit that appears in fog and coastal mist. Special ability: **Drowning Field** (creatures within 10 ft. must save vs. suffocation each round). Great for harbor or island encounters.
+
+### 7. Bleached Oracle
+*Small fey, neutral good (usually)* — CR 2. A small white fox that speaks in riddles and sells information. Technically harmless. Infuriating. Its answers are always true and always incomplete. Good roleplaying encounter.
+
+### 8. Null Hound
+*Large monstrosity, unaligned* — CR 8. A magical predator that suppresses spellcasting in a 30-ft. aura. Devastating against casters. Physically unremarkable, which makes it terrifying when the party's wizard goes silent mid-combat.
+
+### 9. Veilstag
+*Huge fey, chaotic neutral* — CR 11. A massive stag that phases between the material plane and the feywild. **Phase Shift**: can teleport up to 120 ft. as a bonus action. Leaves behind a trail of crushed flowers. Immune to being tracked by mundane means.
+
+### 10. Permafrost Wurm
+*Gargantuan monstrosity, unaligned* — CR 15. A massive worm that burrows through frozen earth and ice. Creates tremors as a lair action. **Blizzard Breath** (cone, cold damage + blindness). The region boss encounter for a high-level arctic campaign.
+
+---
+
+These monsters are designed to be dropped in directly or adapted freely. If you use them in your game, we'd love to hear what happened — share your session stories in our [Discord community](https://discord.gg/frozendice).
+
+**Want the full stat blocks for entries 6–10, plus encounter tables and lair maps?** They're in our [homebrew supplement in the store](/store). And [sign up for our newsletter](/newsletter) — we release new homebrew content every month.

--- a/content/blog/character-backstory-prompts-that-actually-matter.mdx
+++ b/content/blog/character-backstory-prompts-that-actually-matter.mdx
@@ -4,7 +4,7 @@ slug: "character-backstory-prompts-that-actually-matter"
 excerpt: "Most D&D backstories are forgotten by session three. These prompts help you build character history that creates real hooks, meaningful relationships, and moments your whole table will remember for years."
 coverImage: ""
 ogImage: "/images/blog/character-backstory-prompts.jpg"
-publishedAt: "2026-05-01"
+publishedAt: "2026-04-28"
 tags: ["character-creation", "backstory", "roleplay", "dm-advice"]
 categories: ["Guides"]
 author: "Frozen Dice"

--- a/content/blog/character-backstory-prompts-that-actually-matter.mdx
+++ b/content/blog/character-backstory-prompts-that-actually-matter.mdx
@@ -1,0 +1,149 @@
+---
+title: "Character Backstory Prompts That Actually Matter in D&D"
+slug: "character-backstory-prompts-that-actually-matter"
+excerpt: "Most D&D backstories are forgotten by session three. These prompts help you build character history that creates real hooks, meaningful relationships, and moments your whole table will remember for years."
+coverImage: ""
+ogImage: "/images/blog/character-backstory-prompts.jpg"
+publishedAt: "2026-05-01"
+tags: ["character-creation", "backstory", "roleplay", "dm-advice"]
+categories: ["Guides"]
+author: "Frozen Dice"
+---
+
+# Character Backstory Prompts That Actually Matter in D&D
+
+Most D&D character backstories follow a recognizable pattern: tragic origin, dead mentor, vague quest for revenge or redemption, solo hero who works alone. It reads like a résumé, and like most résumés, it's forgotten within a week.
+
+The problem isn't the backstory itself — it's that most backstories are written in isolation, without considering what makes them *playable*. A great backstory isn't just about who your character was. It's about what your character *wants*, what they're *afraid of*, and what *hooks* they give the DM to pull on.
+
+These prompts are designed to build exactly that.
+
+---
+
+## Why Most Backstories Don't Work
+
+Before the prompts, a quick diagnosis.
+
+**They're too long.** A four-page backstory is a novel outline, not a character sheet entry. DMs won't retain it. Other players won't read it. Write for the table, not for yourself.
+
+**They resolve everything.** If your character has already found inner peace, overcame their trauma, and learned the important lesson — what's left? Backstory should create *open* questions, not answer them.
+
+**They exist in a vacuum.** Your character didn't grow up alone in a featureless void. They come from somewhere specific, knew specific people, and those people are still out there. Backstory that ignores setting and other characters misses half its potential.
+
+---
+
+## The Five Questions That Matter
+
+If you only do five things, do these. These questions are borrowed from story structure and adapted for tabletop play.
+
+### 1. What does your character *want* right now?
+
+Not "what do they need" or "what's their arc" — what do they actively want? Be specific. "I want to be respected" is weak. "I want to convince the Thieves' Guild in Rimhavn to reinstate my membership so I can access their fence network" is a hook.
+
+Your DM can work with concrete wants. Abstract desires are invisible at the table.
+
+### 2. What are they afraid will happen if they fail?
+
+Fear is the engine of character motivation. Not "they'll die" — everyone might die. What loss is uniquely theirs? Loss of someone specific? Loss of identity? Loss of a truth they've been clinging to?
+
+Fear makes characters act. It also makes for painful, interesting moments when the DM decides to test it.
+
+### 3. Who do they love, hate, or owe?
+
+One person in each category. Name them. Give them a location. Make them reachable.
+
+This is relationship infrastructure. Your DM now has three named NPCs who matter to your character and can show up at any time. The person you love creates a vulnerability. The person you hate creates a potential conflict. The person you owe creates an obligation that might override the party's goals at the worst possible moment.
+
+### 4. What lie are they telling themselves?
+
+Every interesting character has a blind spot — something they believe that isn't quite true. "I don't need anyone." "I can handle anything." "My family was good people." "I deserved what happened to me."
+
+This is your character's internal arc. As the campaign progresses, the story will challenge this lie. You don't have to resolve it right away. Just know what it is.
+
+### 5. What do they *not* talk about?
+
+The most interesting parts of a person's history are the things they avoid. Pick one event or secret your character never voluntarily discusses. When it comes up — through another character's prying, or a DM's narrative forcing function — lean in. That's when backstory becomes performance.
+
+---
+
+## Setting-Specific Prompts (For Frozen North Campaigns)
+
+If you're playing in a northern or Norse-inspired setting like [a frozen north campaign world](/blog/building-a-frozen-north-campaign-setting), these prompts add flavor grounded in that environment.
+
+- **Your village was destroyed by something.** Was it a monster, a rival clan, an avalanche triggered by something magical? Do you know what really caused it, or only what survivors told you?
+- **You've survived a winter alone.** When, where, and why were you isolated? What did you have to do to make it? What part of that do you not tell people?
+- **You've seen the northern lights shift to red.** The locals say it means something has awakened. You were there when it happened. What were you doing? What did you do next?
+- **You owe a debt to a jarl, spirit, or traveling merchant.** What was the exchange? Is the debt paid, outstanding, or disputed?
+- **You carry something that doesn't belong to you.** A runestone, a weapon, a letter, a child. Where did it come from? Why haven't you gotten rid of it?
+
+---
+
+## Prompts for Specific Character Classes
+
+### Fighters and Barbarians
+
+- Who trained you, and why did they stop?
+- You've won a fight you weren't supposed to win. What were the consequences?
+- There's a weapon you won't use. What is it, and why?
+
+### Wizards and Sorcerers
+
+- What's the first spell you ever cast, and what happened?
+- Someone taught you something you weren't supposed to know. Who? What did it cost them?
+- What do you study when no one's watching?
+
+### Rogues and Rangers
+
+- Who have you betrayed? Did they survive it?
+- What city or place can you never return to?
+- You were caught once. How did you get free?
+
+### Clerics and Paladins
+
+- What did you pray for that your god didn't answer? How did you reconcile that?
+- What would make you question your faith?
+- What have you done in service to your deity that you're not proud of?
+
+### Druids and Monks
+
+- You left a place of peace. What pushed you out?
+- What do you miss most about the life you left behind?
+- The natural world has shown you something unsettling. What was it?
+
+### Bards and Warlocks
+
+- What story do you tell that isn't entirely true?
+- Your patron (or greatest audience) wants something from you. What is it? Do you intend to give it?
+- Who in your past do you still perform for, even though they're gone?
+
+---
+
+## The Collaborative Backstory Technique
+
+Before finalizing your character, share your answers to the five core questions with the other players and the DM. Then ask: **does anything connect?**
+
+Maybe the person your character owes a debt to is the same person another character is hunting. Maybe two characters share a lie. Maybe everyone at the table served under the same commander who is now listed as missing.
+
+These connections don't have to be dramatic. Even a small overlap — two characters from the same city, or both having survived the same event from different sides — creates chemistry. Chemistry makes roleplay feel effortless.
+
+---
+
+## The Backstory One-Pager
+
+Write your backstory in under 300 words. Use this structure:
+
+1. **Origin**: One sentence about where you're from and who raised you.
+2. **Inciting event**: The moment your character's life changed and they ended up on a path that led to this table.
+3. **The five questions**: Brief answers to each.
+4. **Three named people**: One loved, one hated, one owed.
+5. **One open secret**: Something you haven't told anyone at the table yet.
+
+Give this to your DM before session one. Then let the campaign fill in the rest.
+
+---
+
+The best D&D moments aren't scripted. They happen when backstory collides with the present: when the person you owe walks into the tavern, when your lie gets tested in public, when the thing you're afraid of becomes the only solution.
+
+Build backstory that creates *possibility*, and the story will generate itself.
+
+**Ready to bring your character to life?** Check out our [session zero checklist](/blog/session-zero-checklist-for-new-groups) to make sure your whole group is aligned before play starts. And join our [Discord community](https://discord.gg/frozendice) — we've got a dedicated character workshop channel where players share backstories and get feedback. [Sign up for our newsletter](/newsletter) for more character creation guides every week.

--- a/content/blog/how-to-run-a-sandbox-campaign.mdx
+++ b/content/blog/how-to-run-a-sandbox-campaign.mdx
@@ -4,7 +4,7 @@ slug: "how-to-run-a-sandbox-campaign"
 excerpt: "Sandbox campaigns give players total freedom — and most DMs secretly dread them. Here's how to prep the right way, keep momentum going, and run an open-world D&D campaign that doesn't collapse under its own weight."
 coverImage: ""
 ogImage: "/images/blog/sandbox-campaign-guide.jpg"
-publishedAt: "2026-05-08"
+publishedAt: "2026-05-05"
 tags: ["sandbox", "dm-advice", "campaign-design", "worldbuilding"]
 categories: ["Guides"]
 author: "Frozen Dice"

--- a/content/blog/how-to-run-a-sandbox-campaign.mdx
+++ b/content/blog/how-to-run-a-sandbox-campaign.mdx
@@ -1,0 +1,154 @@
+---
+title: "How to Run a Sandbox D&D Campaign (Without Losing Your Mind)"
+slug: "how-to-run-a-sandbox-campaign"
+excerpt: "Sandbox campaigns give players total freedom — and most DMs secretly dread them. Here's how to prep the right way, keep momentum going, and run an open-world D&D campaign that doesn't collapse under its own weight."
+coverImage: ""
+ogImage: "/images/blog/sandbox-campaign-guide.jpg"
+publishedAt: "2026-05-08"
+tags: ["sandbox", "dm-advice", "campaign-design", "worldbuilding"]
+categories: ["Guides"]
+author: "Frozen Dice"
+---
+
+# How to Run a Sandbox D&D Campaign (Without Losing Your Mind)
+
+The sandbox is the dream: a living, breathing world where players can go anywhere, do anything, and forge their own path. No railroads. No invisible walls. Just open country and the freedom to explore.
+
+It's also the campaign style that burns out the most DMs.
+
+Not because sandbox is bad — it's one of the most rewarding ways to run D&D. But it requires a fundamentally different approach to preparation. DMs trained on adventure modules assume they need to prep *what will happen*. Sandbox DMs need to prep *what is already happening* and then let player choices drive the story.
+
+Here's how to do it.
+
+---
+
+## The Core Philosophy: Prep the World, Not the Plot
+
+In a linear campaign, you prep scenes. In a sandbox, you prep factions, locations, and timelines.
+
+The world exists independently of the players. Things are happening whether the party shows up or not. The bandit lord is consolidating power. The ancient temple is being excavated by a rival wizard. The jarl's daughter has gone missing. These events move forward on a clock — and the players can engage, ignore, or accidentally accelerate them.
+
+This is called a **living world**, and it's the engine of sandbox play.
+
+---
+
+## Step 1: Build Your Factions First
+
+Factions are the foundational unit of sandbox design. Start with three to five groups in your setting, each with:
+
+- **A goal** (what they want)
+- **A method** (how they're pursuing it)
+- **A resource** (what they have)
+- **An obstacle** (what's in their way — usually another faction)
+
+### Example Factions for a Frozen North Campaign
+
+| Faction | Goal | Method | Resource | Obstacle |
+|---|---|---|---|---|
+| The Frost Jarl | Expand territory before winter | Raids and conscription | Warriors, fortified port | Rival jarl to the south |
+| The Glacier Cult | Awaken something beneath the ice | Ritual excavation | Fanatical followers, ancient maps | The Frost Jarl's patrols |
+| The Merchant Consortium | Secure trade routes | Bribery and negotiation | Gold, information network | Bandit groups on the roads |
+| The Old Druids | Prevent what the Cult is doing | Sabotage, recruiting outsiders | Wilderness knowledge, animal allies | Distrust from settlements |
+
+Now you have the bones of an entire campaign. Players can work with any faction, against any faction, or try to play them against each other. Every choice has consequences that ripple across the whole map.
+
+---
+
+## Step 2: Create a Regional Map With Density, Not Detail
+
+The classic sandbox mistake is building a world that's too big. You design fourteen cities and then the players spend the entire campaign in the starting town.
+
+Start smaller and denser. A region of roughly 50–100 miles. Within that region, place:
+
+- **2–3 settlements** of varying size
+- **5–10 points of interest** (ruins, dungeons, landmarks, natural features)
+- **Faction territories** that overlap and create friction
+
+For each point of interest, write a two-sentence description: what is it, and what's the hook. That's all you need until players head there. Then expand it.
+
+If you're building a northern setting, take inspiration from [building a frozen north campaign](/blog/building-a-frozen-north-campaign-setting) — the key locations framework there translates directly to sandbox design.
+
+---
+
+## Step 3: Use Clocks and Timelines, Not Scripted Events
+
+The biggest technical skill in sandbox DMing is the **faction clock**: a system for tracking what factions do when the players aren't watching.
+
+It works like this. For each faction goal, create a progress track with four to six stages. The faction advances one stage each session (or each game-week, or whatever interval fits your fiction). When they reach the final stage, the thing happens.
+
+### Example: The Glacier Cult's Excavation Clock
+
+| Stage | Event |
+|---|---|
+| 1 | Cult spotted in the Singing Glacier (rumors in Rimhavn) |
+| 2 | First excavation camp established |
+| 3 | Cult finds an inner chamber, workers start disappearing |
+| 4 | A pulse of cold energy emanates from the glacier (felt everywhere) |
+| 5 | The first seal breaks — something begins to stir |
+| 6 | Full awakening. The sleeping entity is free. |
+
+The players can interrupt this at any stage. If they never engage, stage six happens. The world doesn't wait.
+
+This transforms the sandbox from a passive backdrop into an active adversary. Players feel the urgency of competing timelines even without the DM telling them what to do.
+
+---
+
+## Step 4: Run Information as a Resource
+
+In a sandbox, players won't automatically know where to go next. That's fine — but information needs to be *findable*.
+
+Seed every location and NPC with hooks that point to other content. A goblin patrol near the ruins knows where their camp is. The camp has a map fragment. The map fragment shows the location of a buried vault. The vault has correspondence between two factions.
+
+Create **information chains**, not puzzles. Players should always be able to learn *something* by asking around, exploring, or interrogating enemies. The challenge is deciding which thread to pull.
+
+Key sources of information in a sandbox:
+
+- **Tavern rumors**: One true, one false, one about a faction activity
+- **NPC questgivers**: Every named NPC should be able to point to at least one other location
+- **Defeated enemies**: Letters, maps, orders — enemies are mobile quest dispensers
+- **Environmental storytelling**: The burned farmhouse, the hastily buried bodies, the warning signs carved into a bridge
+
+---
+
+## Step 5: Prep Lightly But Specifically
+
+The sandbox DM's prep paradox: you can't prep everything, but unprepared moments kill momentum.
+
+The solution is **targeted prep**. After each session, review where the players are likely to go next. Prep *those* locations in detail. For everywhere else, keep one-line notes.
+
+Weekly prep that works:
+
+1. **Advance faction clocks** (5 minutes) — what happened this week while the players were busy?
+2. **Flesh out the most likely next location** (30 minutes) — rooms, encounters, inhabitants, treasure
+3. **Prepare three random encounter tables** for travel in each region (15 minutes)
+4. **Name five NPCs** you might need (5 minutes — just a name and one-line description)
+
+That's about an hour of prep that supports three to four hours of play. If you over-prep, you'll feel compelled to *use* what you made, and suddenly you're railroading again.
+
+---
+
+## Step 6: Handle "I Don't Know What to Do" at the Table
+
+Even in a sandbox, players sometimes hit decision paralysis. They've got three active hooks and can't choose. Or worse, they've ignored all the hooks and are wandering aimlessly.
+
+Your tools:
+
+- **The obvious hook**: Have a faction NPC directly approach the party with a job, rumor, or threat
+- **The ticking clock**: Remind them that the cult's excavation is progressing (you don't have to say "you're behind")
+- **The personal hook**: Connect an active plot thread to a character backstory — now it's not just abstract world events, it's about *them*
+
+The goal is never to tell players what to do. It's to make options *concrete and legible*. Players choose freely when they understand what they're choosing between.
+
+---
+
+## The Sandbox in Practice
+
+A great sandbox session looks like this: the players decide on a goal, pursue it, and encounter something unexpected that changes their priorities or opens a new thread. The DM is reactive, surprising the players while staying true to the world's internal logic.
+
+You won't get it perfect. Some sessions will feel aimless. Some faction clocks will trigger events the players completely miss. That's okay — it means the world is real. A world that pretends to react to players isn't actually a sandbox, it's a sandbox *aesthetic*.
+
+Start small, prep factions and clocks, and trust the players to drive the story.
+
+---
+
+**Want the complete Frozen Dice sandbox toolkit?** We've got faction tracking sheets, clock templates, and regional map generators in our [store](/store). Join our [Discord community](https://discord.gg/frozendice) to share sandbox stories — what moments surprised your players most? And [sign up for the newsletter](/newsletter) for weekly DM prep guides.

--- a/content/blog/session-zero-checklist-for-new-groups.mdx
+++ b/content/blog/session-zero-checklist-for-new-groups.mdx
@@ -4,7 +4,7 @@ slug: "session-zero-checklist-for-new-groups"
 excerpt: "Session zero is the single most important session your group will ever play. Use this checklist to align expectations, build trust, and set your campaign up for success before the first dice roll."
 coverImage: ""
 ogImage: "/images/blog/session-zero-checklist.jpg"
-publishedAt: "2026-04-24"
+publishedAt: "2026-04-21"
 tags: ["session-zero", "beginners", "dm-advice", "group-dynamics"]
 categories: ["Guides"]
 author: "Frozen Dice"

--- a/content/blog/session-zero-checklist-for-new-groups.mdx
+++ b/content/blog/session-zero-checklist-for-new-groups.mdx
@@ -1,0 +1,153 @@
+---
+title: "The Ultimate Session Zero Checklist for New D&D Groups"
+slug: "session-zero-checklist-for-new-groups"
+excerpt: "Session zero is the single most important session your group will ever play. Use this checklist to align expectations, build trust, and set your campaign up for success before the first dice roll."
+coverImage: ""
+ogImage: "/images/blog/session-zero-checklist.jpg"
+publishedAt: "2026-04-24"
+tags: ["session-zero", "beginners", "dm-advice", "group-dynamics"]
+categories: ["Guides"]
+author: "Frozen Dice"
+---
+
+# The Ultimate Session Zero Checklist for New D&D Groups
+
+You've got a group. You've got dice. You're ready to play — but are you really?
+
+Session zero is the conversation that happens *before* the campaign starts. It's not glamorous, and it doesn't involve any dungeon delving. But skip it, and your campaign will hit avoidable walls within the first month. Run it well, and you'll spend the next year at a table where everyone is having the time of their lives.
+
+This checklist covers everything you need to align on before your first real session.
+
+---
+
+## 1. Establish the Tone and Genre
+
+Not everyone has the same D&D in mind. One player wants grimdark tragedy. Another wants whimsical adventure with talking animals. A third is here for tactical combat puzzles.
+
+Ask these questions out loud:
+
+- **How serious do we want the campaign to be?** (Scale of 1–10, with 1 being Monty Python and 10 being Game of Thrones)
+- **What genres excite us?** (Horror, epic fantasy, political intrigue, heist, exploration)
+- **Are we playing a long campaign or a series of shorter arcs?**
+
+There's no wrong answer — but you need to know what table you're sitting down at before you start building characters.
+
+---
+
+## 2. Set Content Boundaries Together
+
+This is the most important part of session zero, and the part most groups skip.
+
+D&D can go to dark places. Violence, manipulation, loss, body horror, trauma — the game doesn't restrict itself. But your table should. **Content lines protect everyone and make bolder storytelling possible**, because players trust that the DM won't blindside them.
+
+Use a simple two-column system:
+
+| Lines (Hard No) | Veils (Fade to Black) |
+|---|---|
+| Topics/content you won't include at all | Topics you'll handle off-screen |
+
+Common lines include: real-world slurs used in-character, sexual content involving minors, graphic torture of player characters. Common veils include: sexual content (acknowledged but not described), animal death, addiction.
+
+Go around the table. Be honest. No one needs to justify their lines.
+
+Also establish an **X-Card or pause system**: a signal anyone can use mid-session to redirect the story without explanation. Knowing it exists means it almost never gets used.
+
+---
+
+## 3. Discuss Character Creation Boundaries
+
+Before anyone rolls stats or picks a subclass, agree on:
+
+- **Which sourcebooks are allowed?** (Core only, or anything official, or third-party too?)
+- **Point buy, standard array, or rolled stats?** (Rolled is fun but can create power imbalances)
+- **Starting level?** (Level 1 is traditional; level 3 means everyone has their subclass immediately)
+- **Are evil or morally grey characters okay?** (One chaotic evil character can derail a group that isn't ready for it)
+- **Do characters know each other?** (Pre-existing relationships reduce the "why would we work together?" problem)
+
+If you're new to the game, consider starting with the [5 tips for new dungeon masters](/blog/5-tips-for-new-dungeon-masters) before finalizing house rules — there are a few rookie traps worth avoiding.
+
+---
+
+## 4. Talk About Scheduling and Commitment
+
+Campaigns die from scheduling problems more than any other cause. Be ruthlessly honest here.
+
+- **How often will you play?** (Weekly, biweekly, monthly?)
+- **What happens when someone can't make it?** (Cancel? Play with a smaller group? NPC the missing character?)
+- **What's the minimum attendance to run a session?**
+- **Is there a session cap?** (Some groups commit to 12 sessions, then reassess)
+
+If someone can only commit to one session a month, that's fine — but everyone needs to know it going in.
+
+---
+
+## 5. Define the DM's Role and Table Expectations
+
+Being a DM is a lot of work. It's also collaborative, not adversarial. Clarify:
+
+- **Is the DM's ruling final mid-session?** (Most tables say yes, look it up after)
+- **How much improvisation vs. prepared content?** (Some DMs prep 20-page documents; others wing it entirely)
+- **What's the note-taking policy?** (Shared doc? Individual notes? The DM keeps records?)
+- **Are players expected to engage with downtime and between-session content?**
+
+Also: tell the DM what you want to see. Seriously. If you want your backstory to matter, say so. If you're hoping for a romance subplot, mention it. If you hate puzzles, let them know now.
+
+---
+
+## 6. World and Character Integration
+
+If the DM has a prepared setting (like a [frozen north campaign world](/blog/building-a-frozen-north-campaign-setting) with its own lore and factions), this is the time to integrate your characters into it.
+
+Questions to answer:
+
+- Where is your character from in this world?
+- How did your character meet the others?
+- What does your character want? What do they fear?
+- Is your character aware of the main threat or conflict, or are they pulled into it?
+
+Work through character backgrounds together. The best backstories aren't written in isolation — they're written in conversation with the DM and other players.
+
+---
+
+## 7. Agree on Metagaming Rules
+
+"Metagaming" — using out-of-character knowledge in-character — is fine up to a point and annoying beyond it. Talk about where your table sits.
+
+- Can players tell each other what their characters are planning out loud?
+- Is it okay to look up monster stat blocks mid-combat?
+- How much do characters know about common D&D tropes? (Does your elf character *know* that beholders are vulnerable to antimagic fields?)
+
+There's no universally correct answer. Just have the conversation.
+
+---
+
+## 8. End With Collaborative Character Questions
+
+Close session zero with something generative. Each player answers:
+
+1. What's one thing your character is proud of?
+2. What's one thing your character regrets?
+3. What's one secret your character is keeping from the group?
+4. What does your character *want* by the end of this campaign?
+
+These answers give the DM a roadmap. They also start to create the inter-character dynamics that make groups memorable.
+
+---
+
+## The Session Zero One-Pager
+
+If you want to capture everything in writing, create a simple shared doc with:
+
+- Tone/genre summary
+- Content lines and veils list
+- Character creation rules
+- Scheduling agreement
+- House rules
+
+Review it when disputes come up. Update it if the campaign evolves.
+
+---
+
+Session zero takes two to three hours. It's the best investment you can make in a campaign that could last years. And once you're aligned? The only thing left to do is play.
+
+**Want to keep building toward your first session?** Join our [Discord community](https://discord.gg/frozendice) to swap session zero tips with other DMs and players, or [sign up for our newsletter](/newsletter) for weekly D&D guides straight to your inbox.

--- a/content/blog/worldbuilding-with-the-1-page-method.mdx
+++ b/content/blog/worldbuilding-with-the-1-page-method.mdx
@@ -1,0 +1,163 @@
+---
+title: "Worldbuilding with the 1-Page Method: Build D&D Worlds That Actually Get Used"
+slug: "worldbuilding-with-the-1-page-method"
+excerpt: "Most DMs build too much world and use too little of it. The 1-Page Method forces you to make every detail count — and gets you from blank page to playable campaign setting in under two hours."
+coverImage: ""
+ogImage: "/images/blog/one-page-worldbuilding.jpg"
+publishedAt: "2026-05-22"
+tags: ["worldbuilding", "dm-advice", "campaign-design", "homebrew", "beginners"]
+categories: ["Guides"]
+author: "Frozen Dice"
+---
+
+# Worldbuilding with the 1-Page Method: Build D&D Worlds That Actually Get Used
+
+Most DMs have a folder somewhere. A Google Doc graveyard. Seventeen pages of geography for a continent the players never visited. A detailed noble lineage chart for a city they bypassed after session two. A cosmology explaining how magic works that no one ever asked about.
+
+This is worldbuilder's disease: the compulsion to build complete before you build *useful*.
+
+The 1-Page Method is an antidote. It forces you to define only what matters most — the things that will actually appear at the table — and leaves intentional blank space for everything else. You can run a satisfying campaign from one page of notes. You genuinely cannot run one from thirty pages that are missing the essential.
+
+---
+
+## What Goes on the Page
+
+The page has five sections. Together they answer the questions your players will actually ask in session one.
+
+---
+
+### Section 1: The Premise (50 words max)
+
+One paragraph. What is this world, and what's the central tension?
+
+Not the history of the world. Not the cosmology. The *premise*: the thing that makes this setting feel alive and in conflict right now.
+
+**Bad example:** "Aetherion is a world of floating islands connected by sky bridges, settled millennia ago by the Celestian Empire which fell three hundred years ago, leaving behind magical artifacts and fractured successor states..."
+
+**Good example:** "The Frozen Reaches: an arctic frontier where two rival jarls are racing to claim land before winter makes travel impossible. Beneath the glaciers, something old is waking up. The locals know it, but no one powerful enough to stop it is paying attention."
+
+The premise is what you say when someone asks "what's your campaign about?" If you can't say it in two sentences, you don't have a premise yet.
+
+---
+
+### Section 2: The Three Factions (3 rows)
+
+Three groups in your setting. Each row has four columns: **Name**, **What They Want**, **What They Control**, **Who They're In Conflict With**.
+
+That's it. No leaders. No history. No organizational chart. You can add those later, when the players interact with the faction and you need the detail.
+
+**Example:**
+
+| Faction | Want | Control | In Conflict With |
+|---|---|---|---|
+| The Frost Jarl's Court | Territorial expansion and tribute | Northern ports, conscript army | The Southern Coalition |
+| The Glacier Cult | Awaken the entity beneath the ice | Excavation sites, fanatics | The Old Druids |
+| The Merchant Consortium | Secure and tax trade routes | Gold, information network | Bandit confederacy |
+
+These three rows are the engine of your campaign. Every story beat connects to one or more of these factions. Every NPC belongs to one of them, is being pressured by one of them, or is trying to stay neutral between them.
+
+If you're building a Nordic setting, this pairs naturally with the location work in [building a frozen north campaign setting](/blog/building-a-frozen-north-campaign-setting) — the factions give the locations their *purpose*.
+
+---
+
+### Section 3: Six Locations (6 rows)
+
+Not a complete map. Six named places, each with a two-sentence description: what it is, and what the hook is.
+
+**Format:** `[Name] — [What it is]. [Why the players might go there or what's happening there.]`
+
+**Example:**
+
+- **Rimhavn** — A trading port built into coastal cliffs, heated by geothermal vents. The Jarl here needs outsiders who can go places his soldiers can't.
+- **The Singing Glacier** — A massive ice sheet that produces harmonic sounds when wind passes through it. The Cult is excavating somewhere inside its northern face.
+- **Ulvskog (Wolf Wood)** — Dense boreal forest where druids maintain an uneasy truce with the local wolf packs. They know what the Cult is doing and are looking for help.
+- **The Barrow Fields** — Flat ground east of Rimhavn, dotted with ancient burial mounds. Some have been disturbed recently. No one is claiming responsibility.
+- **The Black Reach** — A deep-water fjord that never freezes. Strange lights have been seen beneath the surface at night.
+- **The Spire of Voices** — A ruined watchtower on a cliff edge. Local legend says it was the first thing the sleeping entity destroyed. It's structurally unsound but also the best vantage point for fifty miles.
+
+You now have a functional regional map in your head, even without drawing it. Players will go to some of these places. You'll expand the ones they visit. You'll leave the others as rumors.
+
+---
+
+### Section 4: Five Named NPCs (5 rows)
+
+Five people the players will meet in the first few sessions. Each row: **Name**, **Role/Affiliation**, **What They Want From the Players**, **One Secret**.
+
+The secret is the important part. Flat NPCs are forgettable. NPCs with hidden agendas, hidden knowledge, or hidden pain are memorable.
+
+**Example:**
+
+| Name | Role | What They Want | Secret |
+|---|---|---|---|
+| Sigrid Ironwater | Innkeeper, Rimhavn | Steady business, no trouble | She knows which burial mounds were disturbed — she helped |
+| Halvard the Pale | Frost Jarl's spymaster | Information about the Cult | He's been approached by the Cult. He hasn't said no yet |
+| Yda | Old Druid, Ulvskog | Someone to stop the excavation | She knows what's being awakened. It's not evil. It's something worse |
+| Brennar | Merchant Consortium courier | Reliable muscle for a delivery job | The delivery is bait. He's testing whether the party can be trusted |
+| The Questioner | Unknown — found in the ruins | Nothing obvious | She's been there for years. She might not be human. She answers questions with questions |
+
+These five NPCs will recur throughout the campaign. As you learn more about what the players care about, you'll develop the NPCs they respond to. The others can stay sketched until needed.
+
+---
+
+### Section 5: Three Clocks (3 rows)
+
+Clocks are the events that will happen if the players do nothing. Three is enough to start. Each clock has: **Name**, **Current Stage**, **What Happens at Stage 6**.
+
+**Example:**
+
+| Clock | Current Stage | Stage 6 Outcome |
+|---|---|---|
+| The Excavation | Stage 2 — camp established | Entity awakens; weather in the region becomes permanently hostile |
+| The Jarl's Expansion | Stage 1 — massing troops | War begins; all trade through Rimhavn disrupted |
+| The Barrow Disturbance | Stage 3 — movement at night | Whatever was buried there walks the Barrow Fields in force |
+
+Advance each clock one stage each in-game week, or after a significant session event. Players don't need to know the clocks exist — they just see the world changing around them.
+
+---
+
+## The Blank Space Rule
+
+Here's the crucial part: **everything that isn't on this page is blank on purpose.**
+
+You don't know who the entity beneath the glacier is. You don't know the full history of the Frost Jarl's lineage. You don't know what the Questioner actually is. These are blank spaces, not gaps.
+
+When players ask about something that isn't on your page, you have two options:
+
+1. **Make it up on the spot** and write it down immediately. The first thing you say is now canon.
+2. **Defer it** ("The locals don't talk about that") and decide before next session.
+
+Both are correct. What's not correct is stalling the game to explain that you need to do more worldbuilding before you can answer.
+
+The 1-Page Method works because it trains you to make decisions fast and make them consistent. The consistency comes from the page. The speed comes from practice.
+
+---
+
+## Growing the World
+
+After your first few sessions, you'll know which locations the players want to explore, which factions they've engaged with, and which NPCs they've formed opinions about. Now you expand *those* things.
+
+Add a second page only when you fill the first. Add a third only when you fill the second.
+
+Most campaigns never need more than five pages of notes. The players will forget more world history than you ever write. What they remember is *who* they met, *what* those people wanted, and *what happened* when those wants collided with the party.
+
+That's what the 1-Page Method is designed to produce: the minimum viable world that generates maximum story.
+
+---
+
+## Your Campaign in the Next Two Hours
+
+Sit down with a blank page — or a blank doc — and work through the five sections in order:
+
+1. Premise (15 minutes)
+2. Three factions (20 minutes)
+3. Six locations (20 minutes)
+4. Five NPCs (25 minutes)
+5. Three clocks (10 minutes)
+
+After that, you're ready to run. Seriously. Run session zero and let the players fill in the blanks with you.
+
+Check out our [session zero checklist](/blog/session-zero-checklist-for-new-groups) when you're ready to bring your players into the world — that's the conversation that turns your one-pager into a collaborative campaign.
+
+---
+
+**Want a printable 1-Page Campaign Template?** We've got a fillable PDF version in our [store](/store) — designed for quick reference at the table. Join our [Discord community](https://discord.gg/frozendice) to share your one-pagers and get feedback from other DMs. And [sign up for the newsletter](/newsletter) for more campaign prep guides every week.

--- a/content/blog/worldbuilding-with-the-1-page-method.mdx
+++ b/content/blog/worldbuilding-with-the-1-page-method.mdx
@@ -4,7 +4,7 @@ slug: "worldbuilding-with-the-1-page-method"
 excerpt: "Most DMs build too much world and use too little of it. The 1-Page Method forces you to make every detail count — and gets you from blank page to playable campaign setting in under two hours."
 coverImage: ""
 ogImage: "/images/blog/one-page-worldbuilding.jpg"
-publishedAt: "2026-05-22"
+publishedAt: "2026-05-19"
 tags: ["worldbuilding", "dm-advice", "campaign-design", "homebrew", "beginners"]
 categories: ["Guides"]
 author: "Frozen Dice"


### PR DESCRIPTION
## Summary

Adds 5 publish-ready long-form D&D blog posts (1200–1800 words each) to fill the launch content pipeline with ~2 months of queued content.

- **Session Zero Checklist for New Groups** — publish Apr 24. Targets "session zero checklist" keyword. Covers tone, content lines, character creation rules, scheduling, and collaborative backstory. Internal links to DM tips and frozen north posts.
- **Character Backstory Prompts That Actually Matter** — publish May 1. Targets "D&D character backstory" keyword. The 5 core questions framework + class-specific prompts + collaborative backstory technique.
- **How to Run a Sandbox Campaign** — publish May 8. Targets "sandbox D&D campaign" keyword. Covers faction design, faction clocks, information chains, and targeted prep. Links to frozen north setting post and /store.
- **10 Homebrew Monsters (with Stat Blocks)** — publish May 15. Targets "homebrew D&D monsters" keyword. 5 full 5e stat blocks (Rimfrost Revenant, Kulde, Glassbone Elk, Runestone Golem, Frost Wight Berserker) + 5 summaries with /store upsell.
- **Worldbuilding with the 1-Page Method** — publish May 22. Targets "D&D worldbuilding" keyword. The full 5-section 1-page framework with worked frozen-north examples. Sells printable template via /store.

## Content spec checklist

- [x] 1200–1800 words each
- [x] H2/H3 structure, scannable
- [x] Frontmatter: title, slug, publishedAt, excerpt, tags, categories, ogImage suggestion
- [x] Internal links to ≥2 other posts or /tools or /store per post
- [x] CTA at the bottom: newsletter + Discord on every post
- [x] Stored as .mdx files matching existing blog format

## Test plan

- [ ] Verify all 5 posts render on `/blog` index
- [ ] Verify individual post routes resolve correctly
- [ ] Check internal links resolve (existing posts + /store + /newsletter)
- [ ] Spot-check word counts and frontmatter validity

🤖 Generated with [Claude Code](https://claude.com/claude-code)