### PR TITLE
Landing hero: stages 3 + 4 wired (blog from Sanity, YouTube embed + LIVE pill + schedule)

### DIFF
--- a/docs/superpowers/specs/2026-04-19-frozendice-redesign-design.md
+++ b/docs/superpowers/specs/2026-04-19-frozendice-redesign-design.md
@@ -50,69 +50,94 @@
 
 ## 3. Landing page (`/`)
 
-### 3.1 Hero: scroll-scrubbed dice animation
+The landing page is a single sticky-pinned hero with **four scroll-linked stages** that share a 121-frame reverse-direction dice canvas as continuous background. Stages cross-fade as scroll progresses; copy, CTAs, and per-stage decorative animations layer over the dice. A floating snow-pill site header overlays the whole experience.
 
-**Technique:** 121-frame WebP image sequence drawn to `<canvas>`, scroll-linked via framer-motion `useScroll` + `useTransform` + `useMotionValueEvent`. Section is pinned with sticky CSS (`h-[500vh]` wrapper + `sticky top-0` content), no JS pinning.
+Architecturally this differs from the original 3-beat single-hero design that was approved at the start of Phase 4. Stages 2 (Patreon), 3 (Blog), and 4 (Streams) are now *inside* the hero pin rather than separate sections following it. Stage 5 (Shop) is reserved for after the hero, displayed against the static final dice frame as background.
 
-**Why framer-motion over GSAP:** framer-motion is already installed; sticky-CSS pinning makes GSAP's pinning ergonomics unnecessary; ~40 KB bundle savings.
+### 3.1 Hero: 4-stage scroll-pinned dice animation
 
-**Assets (responsive, two sets):**
-- **Desktop** (`min-width: 768px`): `public/images/hero/desktop/1.webp`…`121.webp`, 1280px wide, target ~25 KB/frame → ~3 MB total.
-- **Mobile** (below `768px`): `public/images/hero/mobile/1.webp`…`121.webp`, 640px wide, target ~10 KB/frame → ~1.2 MB total.
-- Client picks the set at mount via `window.matchMedia('(min-width: 768px)')`. Preloaded via `new Image()`; skeleton until frame 1 is ready. Canvas redraws on `window.resize` with "contain" fit so the die stays centered at any viewport.
+**Container:**
 
-**Accessibility:** on `prefers-reduced-motion`, replace the canvas with a single static frame (frame 60, mid-roll) on any device. This is an explicit user accessibility preference, not a device-capability guess — the animation runs on mobile by default.
+- Outer wrapper: `position: relative` with `h-[500vh]` (~one viewport-height of scroll per stage) inside `<main>`.
+- Inner sticky div: `sticky top-0 h-screen overflow-hidden bg-black`.
+- Anchor divs at `top: 0%/25%/50%/75%` (`#stage-intro` / `#stage-patreon` / `#stage-blog` / `#stage-streams`) provide deep-link targets and `scroll-smooth` jumps.
+- Page root requires `position: relative` on `<html>` so framer-motion's scroll-container measurements resolve.
 
-**Implementation checkpoint:** during phase 4, real-device test on a mid-range Android (e.g. Pixel 6a or equivalent). If the 121-frame scrub stutters visibly on the mobile asset set, fall back to snapping to every-2nd frame on mobile (60 frames drawn, 121 mapped). Design stays the same; only the canvas draw cadence changes.
+**Asset pipeline:**
 
-**Narrative copy, mapped to scroll progress (three beats):**
+Source video `frozendice_dice/frozendice_animation.mp4` (h264, 1928×1072, 24 fps × 5 s = 121 frames). One-shot `scripts/optimize-hero-frames.ts` decodes the video to lossless PNG via `ffmpeg-static`, then sharp encodes two WebP sets:
 
-- **Beat 1 (0–33%)** — die tumbles in. H1 *"FrozenDice"*, tagline *"Cold dice. Hot stories."* (placeholder; tunable without code).
-- **Beat 2 (33–66%)** — die mid-roll, snow swirling. H2 *"Live D&D from the frozen north."*, sub *"Original campaigns. Nordic lore. Streamed weekly on YouTube."*
-- **Beat 3 (66–100%)** — die settles, snow drifts. H2 *"Join the saga."* + three CTA buttons:
-  - **Patreon** (primary, filled, brand accent) → `patreon.com/frozendice`
-  - **Watch Live** (secondary, outlined) → YouTube channel
-  - **Shop** (secondary, outlined) → `/store`
+- **Desktop:** source resolution 1928px wide, Q85, effort 6, ~85 KB/frame → ~10 MB total.
+- **Mobile:** 800px wide, Q82, effort 6, ~30 KB/frame → ~3.5 MB total.
 
-Copy overlays fade in/out via `useTransform(scrollYProgress, [a, b, c, d], [0, 1, 1, 0])` per beat.
+Output committed to `public/images/hero/{desktop,mobile}/N.webp`. The intermediate PNG temp dir is removed after each run. `frozendice_dice/` is gitignored; the source `.mp4` is kept locally as backup.
 
-### 3.2 Patreon section
+**Canvas:**
 
-**Layout:** two-column sticky.
+- Scroll-linked via framer-motion `useScroll({ target: heroRef, offset: ["start start", "end end"] })` lifted into `HeroSection`. `frameIndex = useTransform(scrollYProgress, [0, 1], [TOTAL_FRAMES, 1])` — **reverse direction**: the die starts settled (frame 121) at the top of the page and rolls away to frame 1 as the user scrolls through all four stages.
+- Cover-fit painting (`Math.max` scale) so the dice fills the viewport at any aspect ratio — no letterbox.
+- Internal pixel buffer is `window.innerWidth × devicePixelRatio` (capped at 2×) for crisp rendering on retina/4K displays.
+- Asset set picked at mount via `window.matchMedia('(min-width: 768px)')`. All frames are preloaded via `new Image()`; `onload` is wired before `src` to handle synchronous cache-hits (frame 1 is preloaded via `<link rel="preload" fetchPriority="high">` so it appears at LCP).
+- `drawFrame(n)` falls back to the nearest already-loaded earlier frame if frame N hasn't arrived yet, eliminating mid-scrub blank flashes.
 
-- **Left (sticky):** eyebrow *"Patreon"*, headline *"The full saga lives here."*, short body on member perks, primary CTA *"Become a Patron →"* (external).
-- **Right (scroll-animated):** stack of 4–5 "pages" representing D&D artifacts members unlock — campaign map, monster stat block, NPC portrait + bio, handwritten journal / session recap, Discord community moment.
+**Reduced motion:** `prefers-reduced-motion: reduce` collapses the wrapper to `h-screen` (no scroll pinning), loads only frame 60 (skipping the other 120 entirely — saves ~9 MB), and renders Stage 1 statically with CTAs pointing at direct external destinations (since `#stage-X` anchors don't exist in this mode).
 
-**Animation:** dealt-card reveal. Each page flies in from offscreen, rotates slightly, stacks/fans like cards dealt onto a tavern table. framer-motion `useTransform` on rotation + translation, staggered by mapping each card to a different scroll range.
+**Stage 1 — Intro (scroll 0–25%, visible at scroll 0):**
 
-**Below the stack (optional):** tier summary (2–3 placeholder tiers, e.g. *Campfire / Ranger / Dragonslayer*). Patreon itself remains the pricing source of truth.
+- Left-aligned panel, `max-w-xl`.
+- H1 *"FrozenDice"*, tagline *"Cold dice. Hot stories."*, intro paragraph mentioning live D&D + Patreon + blog.
+- Three CTAs: **Become a Patreon** (primary, brand-red `#FF424D`) → `patreon.com/FrozenDice`; **Read the Blog** → `/blog`; **Watch Stream** → channel handle URL.
+- Opacity is computed via the function form of `useTransform` (every scroll position maps to an explicit return value, avoiding keyframe-interpolation edge cases). `visibleAtStart: true` flag holds opacity at 1 from scroll 0 through 20%, then fades to 0 by 25%.
 
-**Content source:** Sanity `patreonPerks` singleton — ordered array of `{ image, label, blurb }` cards, plus tier summary fields.
+**Stage 2 — Patreon (scroll 25–50%):**
 
-### 3.3 Streams / VOD section
+- Two-column layout. Left: eyebrow *"Patreon"*, headline *"The full saga lives here."*, body, *"Become a Patreon →"* CTA.
+- Right (desktop only, `hidden lg:block`): three placeholder PDF cards fly in from off-screen-right via `useTransform(scrollYProgress, [in, out], [800, 0])` between scroll progress 0.28 and 0.42, staggered. Cards use page-mockup styling (header bar, faux text rows, image block placeholder).
+- Final art replaces placeholders with real PDF preview images of Patreon perks. Sanity-backed via the Phase 1 `patreonPerks` singleton (TODO — currently hardcoded copy).
 
-**Layout:**
+**Stage 3 — Blog (scroll 50–75%):**
 
-- Eyebrow *"Live & on-demand"*, headline *"Watch the saga unfold."*
-- **Hero player (always visible):** YouTube embed at `youtube.com/embed/live_stream?channel=<CHANNEL_ID>` — YouTube auto-serves the live stream when live, falls back to the channel's recent premiere/pinned video otherwise.
-- **LIVE pill overlay** (pulsing red dot) when channel is live, detected via a polled `/api/youtube/live-status` route handler using YouTube Data API v3 `search.list?eventType=live`.
-- **Schedule strip** — next 2–3 scheduled sessions, e.g. *"Next: Thursday 8pm CET — Session 14: The Glacier's Tomb."* Content from Sanity `streamSchedule` singleton.
-- **VOD grid** — 6 featured VODs rendered from `i.ytimg.com` thumbnails; click opens an inline lightbox with a YouTube iframe. Content from Sanity `featuredVods` array (video IDs + optional titles).
-- **CTA:** *Subscribe on YouTube →* + *See all VODs on YouTube →*.
+- Two-column. Left: eyebrow *"Blog"*, headline *"Dispatches from the frozen north."*, body, *"Read the Blog →"* link.
+- Right (desktop only): up to 3 latest blog posts from Sanity. `(marketing)/page.tsx` server-fetches `getAllPosts()` and transforms `PostCard[]` to a serializable `BlogPreview` shape (slug, title, excerpt, pre-built `coverUrl` string from `urlForImage`, alt, publishedAt) before threading down through the Client overlay. Each preview: 16:9 thumbnail, title (line-clamp-2), excerpt (line-clamp-2), formatted date, link to `/blog/[slug]`.
 
-**Data split (hybrid):** Sanity owns curated VODs + schedule (editor pastes video IDs after each stream). YouTube Data API owns live status only.
+**Stage 4 — Streams (scroll 75–100%):**
 
-**Quota:** default 10k units/day. `search.list?eventType=live` costs 100 units/call; 60-second `revalidate` in the route handler keeps us well under budget.
+- Two-column. Left: eyebrow *"Live & on-demand"*, headline *"Watch the saga unfold."*, body, *"Subscribe on YouTube →"* CTA. Below the CTA: up to 2 upcoming sessions from Sanity `streamSchedule.upcoming` as glassmorphic cards (title + formatted date/time).
+- Right (desktop only): YouTube live embed `youtube.com/embed/live_stream?channel=<id>` — channel ID from `streamSchedule.youtubeChannelId` with fallback to `NEXT_PUBLIC_YOUTUBE_CHANNEL_ID`. YouTube auto-serves the live stream when live, falls back to the channel's recent video otherwise.
+- **LIVE pill** overlay (pulsing red dot + "LIVE" label, `bg-black/70 backdrop-blur-sm`) appears when `/api/youtube/live-status` returns `{isLive: true}`. The route handler polls YouTube Data API v3 `search.list?eventType=live&channelId=<id>&type=video` (100 quota units/call) and is cached for 60 s — keeps the daily call count well under the 10k unit quota.
+- **VOD grid (TODO):** 6 featured VOD thumbnails with click-to-play `<dialog>` lightbox, sourced from Sanity `featuredVods` singleton. Pending follow-up; Stage 4 currently renders embed + schedule only.
 
-### 3.4 Shop featured items section
+**Stage 5 — Shop (TODO, post-hero):**
 
-**Layout:** eyebrow *"Shop"*, headline *"Gear for your table."*, one-line sub. **3-up grid** of featured products.
+- Below the sticky hero, against the static frame-1 dice as background.
+- 3-up featured products grid reusing `ProductCard` from `/store`, query `*[_type == "product" && featured == true && isPublished == true][0...3]`, `whileInView` staggered fade-in.
+- Deferred until Phase 3 ships the underlying product schema and storefront.
 
-**Cards:** image, name, one-line description, price, *View product →* link to `/store/[slug]`. Staggered `opacity + translateY` on scroll (`whileInView`), subtle hover lift. Reuses the same `ProductCard` component as `/store`.
+### 3.2 Render-context threading
 
-**Query:** `*[_type == "product" && featured == true && isPublished == true][0...3]`.
+`HeroCopyOverlay` is a Client Component (uses framer-motion hooks). Per-stage data fetched on the server (Sanity blog posts, stream schedule) is threaded through a `StageRenderContext` object passed to each stage's `render` function:
 
-**Footer link:** *See all products →* to `/store`.
+```ts
+type StageRenderContext = {
+  scrollYProgress: MotionValue<number>;
+  blogPreviews: BlogPreview[];
+  streamSchedule: StreamSchedule | null;
+};
+```
+
+This avoids prop-drilling and lets future stages receive additional server-resolved data without breaking changes.
+
+### 3.3 Site header
+
+Sticky-pill floating header (`position: fixed; top: 1rem; mx-auto w-fit`) overlaying the hero at all times. Three layers stacked:
+
+1. **Outer halo** — `bg-white/20 blur-2xl`, soft snow-light glow.
+2. **Snow shell** — `bg-white/70` with SVG turbulence displacement filter (`feTurbulence baseFrequency=0.85 numOctaves=2 + feDisplacementMap scale=5`) for organic flurry edges. Filter applied via `.snow-flurry-edge` utility class in `globals.css`.
+3. **Crisp content pill** — `bg-white/95 backdrop-blur-md rounded-full`, border `white/60`. Logo + nav links (Blog, Tools, About) + primary "Become a Patreon" CTA in brand red.
+
+Mobile collapses to hamburger via shadcn `Sheet`. Same items inside.
+
+The Store nav item is deferred pending Phase 3.
 
 ---
 

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import { HeroSection } from "@/components/landing/hero-section";
 import type { BlogPreview } from "@/components/landing/hero-copy-overlay";
 import { siteConfig } from "@/lib/site-config";
-import { getAllPosts } from "@/sanity/queries";
+import { getAllPosts, getStreamSchedule } from "@/sanity/queries";
 import { urlForImage } from "@/sanity/image";
 import type { PostCard } from "@/sanity/types";
 
@@ -38,7 +38,10 @@ function toBlogPreview(post: PostCard): BlogPreview {
 }
 
 export default async function HomePage() {
-  const allPosts = await getAllPosts();
+  const [allPosts, streamSchedule] = await Promise.all([
+    getAllPosts(),
+    getStreamSchedule(),
+  ]);
   const blogPreviews = allPosts.slice(0, 3).map(toBlogPreview);
 
   return (
@@ -64,9 +67,12 @@ export default async function HomePage() {
         fetchPriority="high"
       />
 
-      <HeroSection blogPreviews={blogPreviews} />
+      <HeroSection
+        blogPreviews={blogPreviews}
+        streamSchedule={streamSchedule}
+      />
 
-      {/* TODO(phase-4): add Patreon, Streams, Featured Products as sections following the hero, when each iteration lands. */}
+      {/* TODO: add /api/revalidate handling for streamSchedule + featuredVods tags when those Sanity types are wired into the webhook. */}
     </>
   );
 }

--- a/src/app/(marketing)/page.tsx
+++ b/src/app/(marketing)/page.tsx
@@ -1,6 +1,10 @@
 import type { Metadata } from "next";
 import { HeroSection } from "@/components/landing/hero-section";
+import type { BlogPreview } from "@/components/landing/hero-copy-overlay";
 import { siteConfig } from "@/lib/site-config";
+import { getAllPosts } from "@/sanity/queries";
+import { urlForImage } from "@/sanity/image";
+import type { PostCard } from "@/sanity/types";
 
 export const metadata: Metadata = {
   title: {
@@ -18,7 +22,25 @@ export const metadata: Metadata = {
   },
 };
 
-export default function HomePage() {
+// Resolve Sanity types into the serializable shape Stage 3 needs. Image URLs
+// are pre-built here so the Client Component never touches @sanity/image-url.
+function toBlogPreview(post: PostCard): BlogPreview {
+  return {
+    slug: post.slug,
+    title: post.title,
+    excerpt: post.excerpt,
+    coverUrl: post.coverImage
+      ? urlForImage(post.coverImage).width(320).height(180).auto("format").url()
+      : null,
+    coverAlt: post.coverImage?.alt ?? post.title,
+    publishedAt: post.publishedAt,
+  };
+}
+
+export default async function HomePage() {
+  const allPosts = await getAllPosts();
+  const blogPreviews = allPosts.slice(0, 3).map(toBlogPreview);
+
   return (
     <>
       {/*
@@ -42,9 +64,9 @@ export default function HomePage() {
         fetchPriority="high"
       />
 
-      <HeroSection />
+      <HeroSection blogPreviews={blogPreviews} />
 
-      {/* TODO(phase-4): add PatreonSection, StreamsSection, FeaturedProductsSection in subsequent sessions */}
+      {/* TODO(phase-4): add Patreon, Streams, Featured Products as sections following the hero, when each iteration lands. */}
     </>
   );
 }

--- a/src/app/api/youtube/live-status/route.ts
+++ b/src/app/api/youtube/live-status/route.ts
@@ -1,0 +1,45 @@
+import { NextResponse } from "next/server";
+
+// Revalidate cached response every 60 seconds. With Next's response caching,
+// the YouTube Data API v3 call (100 quota units) only fires once per minute
+// per deploy region — well under the 10k unit/day quota.
+export const revalidate = 60;
+
+type YouTubeSearchResponse = {
+  items?: unknown[];
+  error?: { message: string };
+};
+
+export async function GET(): Promise<NextResponse> {
+  const apiKey = process.env.YOUTUBE_API_KEY;
+  const channelId = process.env.YOUTUBE_CHANNEL_ID;
+
+  // Missing env: return not-live rather than 500. The LIVE pill hides itself
+  // on isLive: false, so the rest of the page degrades gracefully.
+  if (!apiKey || !channelId) {
+    return NextResponse.json({ isLive: false, error: "env_missing" });
+  }
+
+  const url = new URL("https://www.googleapis.com/youtube/v3/search");
+  url.searchParams.set("part", "id");
+  url.searchParams.set("channelId", channelId);
+  url.searchParams.set("eventType", "live");
+  url.searchParams.set("type", "video");
+  url.searchParams.set("key", apiKey);
+
+  let data: YouTubeSearchResponse;
+  try {
+    const res = await fetch(url.toString(), { next: { revalidate: 60 } });
+    data = (await res.json()) as YouTubeSearchResponse;
+  } catch {
+    return NextResponse.json({ isLive: false, error: "fetch_failed" });
+  }
+
+  if (data.error) {
+    console.error("YouTube live-status API error:", data.error.message);
+    return NextResponse.json({ isLive: false, error: "api_error" });
+  }
+
+  const isLive = Array.isArray(data.items) && data.items.length > 0;
+  return NextResponse.json({ isLive });
+}

--- a/src/components/landing/hero-copy-overlay.tsx
+++ b/src/components/landing/hero-copy-overlay.tsx
@@ -8,7 +8,7 @@ import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
 import type { StreamSchedule } from "@/sanity/types";
 
-const PATREON_URL = "https://www.patreon.com/c/FrozenDice";
+const PATREON_URL = "https://www.patreon.com/FrozenDice";
 const YOUTUBE_FALLBACK = "https://www.youtube.com/@FrozenDice_no";
 
 // Serializable shape passed from the server (page.tsx fetches Sanity, builds

--- a/src/components/landing/hero-copy-overlay.tsx
+++ b/src/components/landing/hero-copy-overlay.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import Image from "next/image";
 import Link from "next/link";
 import { motion, useTransform, type MotionValue } from "framer-motion";
 import { buttonVariants } from "@/components/ui/button";
@@ -8,10 +9,28 @@ import { cn } from "@/lib/utils";
 const PATREON_URL = "https://www.patreon.com/c/FrozenDice";
 const YOUTUBE_FALLBACK = "https://www.youtube.com/@FrozenDice_no";
 
+// Serializable shape passed from the server (page.tsx fetches Sanity, builds
+// these previews, hands them to HeroSection → HeroCopyOverlay → Stage3Blog).
+// All Sanity-specific types are resolved server-side so this Client Component
+// only sees primitive values + the pre-built CDN URL.
+export type BlogPreview = {
+  slug: string;
+  title: string;
+  excerpt: string;
+  coverUrl: string | null;
+  coverAlt: string;
+  publishedAt: string;
+};
+
 function youtubeChannelUrl(): string {
   const id = process.env.NEXT_PUBLIC_YOUTUBE_CHANNEL_ID;
   return id ? `https://www.youtube.com/channel/${id}` : YOUTUBE_FALLBACK;
 }
+
+type StageRenderContext = {
+  scrollYProgress: MotionValue<number>;
+  blogPreviews: BlogPreview[];
+};
 
 type Stage = {
   id: string;
@@ -23,7 +42,7 @@ type Stage = {
   // inStart instead of starting invisible. Used for stage 1 so the intro
   // headline + CTAs are present on page load before any scroll.
   visibleAtStart?: boolean;
-  render: (scrollYProgress: MotionValue<number>) => React.ReactNode;
+  render: (ctx: StageRenderContext) => React.ReactNode;
 };
 
 // 4 stages, each occupying ~25% of the hero scroll. Fade-in over 5%, hold
@@ -44,7 +63,7 @@ const stages: Stage[] = [
     inEnd: 0.3,
     outStart: 0.45,
     outEnd: 0.5,
-    render: (scrollYProgress) => <Stage2Patreon scrollYProgress={scrollYProgress} />,
+    render: (ctx) => <Stage2Patreon scrollYProgress={ctx.scrollYProgress} />,
   },
   {
     id: "stage-3",
@@ -52,7 +71,7 @@ const stages: Stage[] = [
     inEnd: 0.55,
     outStart: 0.7,
     outEnd: 0.75,
-    render: () => <Stage3Blog />,
+    render: (ctx) => <Stage3Blog posts={ctx.blogPreviews} />,
   },
   {
     id: "stage-4",
@@ -146,30 +165,71 @@ function Stage2Patreon({
   );
 }
 
-function Stage3Blog() {
+function Stage3Blog({ posts }: { posts: BlogPreview[] }) {
   return (
-    <div className="hero-text-outline pointer-events-auto max-w-xl">
-      <p className="mb-3 text-sm font-semibold uppercase tracking-widest text-white/80">
-        Blog
-      </p>
-      <h2 className="text-4xl font-bold tracking-tight sm:text-5xl">
-        Dispatches from the frozen north.
-      </h2>
-      <p className="mt-4 text-lg text-white/90">
-        Session recaps, campaign guides, and behind-the-table notes. Read
-        along between streams.
-      </p>
-      <Link
-        href="/blog"
-        className={cn(
-          buttonVariants({ size: "lg", variant: "outline" }),
-          "mt-8",
-        )}
-      >
-        Read the Blog →
-      </Link>
-      {/* TODO(iteration-3): render latest 3 posts from Sanity here. */}
+    <div className="grid w-full grid-cols-1 items-center gap-12 lg:grid-cols-2">
+      <div className="hero-text-outline pointer-events-auto max-w-xl">
+        <p className="mb-3 text-sm font-semibold uppercase tracking-widest text-white/80">
+          Blog
+        </p>
+        <h2 className="text-4xl font-bold tracking-tight sm:text-5xl">
+          Dispatches from the frozen north.
+        </h2>
+        <p className="mt-4 text-lg text-white/90">
+          Session recaps, campaign guides, and behind-the-table notes. Read
+          along between streams.
+        </p>
+        <Link
+          href="/blog"
+          className={cn(
+            buttonVariants({ size: "lg", variant: "outline" }),
+            "mt-8",
+          )}
+        >
+          Read the Blog →
+        </Link>
+      </div>
+      {posts.length > 0 && (
+        <div className="pointer-events-auto hidden flex-col gap-3 lg:flex">
+          {posts.slice(0, 3).map((post) => (
+            <BlogPreviewCard key={post.slug} post={post} />
+          ))}
+        </div>
+      )}
     </div>
+  );
+}
+
+function BlogPreviewCard({ post }: { post: BlogPreview }) {
+  const formattedDate = new Date(post.publishedAt).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+  return (
+    <Link
+      href={`/blog/${post.slug}`}
+      className="group flex gap-3 rounded-lg border border-white/30 bg-white/10 p-3 backdrop-blur-md transition-colors hover:bg-white/20"
+    >
+      {post.coverUrl && (
+        <Image
+          src={post.coverUrl}
+          alt={post.coverAlt}
+          width={120}
+          height={80}
+          className="aspect-video h-20 w-32 shrink-0 rounded object-cover"
+        />
+      )}
+      <div className="min-w-0 flex-1">
+        <p className="line-clamp-2 text-sm font-semibold text-white group-hover:underline">
+          {post.title}
+        </p>
+        <p className="mt-1 line-clamp-2 text-xs text-white/80">{post.excerpt}</p>
+        <p className="mt-1.5 text-[10px] uppercase tracking-widest text-white/60">
+          {formattedDate}
+        </p>
+      </div>
+    </Link>
   );
 }
 
@@ -272,9 +332,11 @@ function PdfCard({
 function StageOverlay({
   stage,
   scrollYProgress,
+  blogPreviews,
 }: {
   stage: Stage;
   scrollYProgress: MotionValue<number>;
+  blogPreviews: BlogPreview[];
 }) {
   // Function-form useTransform: every scroll position maps to an explicit
   // return value. Avoids framer-motion's keyframe-interpolation edge cases
@@ -296,7 +358,7 @@ function StageOverlay({
       style={{ opacity }}
       className="absolute inset-0 flex items-center px-6 sm:px-12 lg:px-24"
     >
-      {stage.render(scrollYProgress)}
+      {stage.render({ scrollYProgress, blogPreviews })}
     </motion.div>
   );
 }
@@ -346,9 +408,11 @@ function ReducedMotionStage1() {
 
 export function HeroCopyOverlay({
   scrollYProgress,
+  blogPreviews,
   reducedMotion = false,
 }: {
   scrollYProgress: MotionValue<number>;
+  blogPreviews: BlogPreview[];
   reducedMotion?: boolean;
 }) {
   if (reducedMotion) {
@@ -362,7 +426,12 @@ export function HeroCopyOverlay({
   return (
     <div className="pointer-events-none absolute inset-0 z-10">
       {stages.map((stage) => (
-        <StageOverlay key={stage.id} stage={stage} scrollYProgress={scrollYProgress} />
+        <StageOverlay
+          key={stage.id}
+          stage={stage}
+          scrollYProgress={scrollYProgress}
+          blogPreviews={blogPreviews}
+        />
       ))}
     </div>
   );

--- a/src/components/landing/hero-copy-overlay.tsx
+++ b/src/components/landing/hero-copy-overlay.tsx
@@ -2,9 +2,11 @@
 
 import Image from "next/image";
 import Link from "next/link";
+import { useEffect, useState } from "react";
 import { motion, useTransform, type MotionValue } from "framer-motion";
 import { buttonVariants } from "@/components/ui/button";
 import { cn } from "@/lib/utils";
+import type { StreamSchedule } from "@/sanity/types";
 
 const PATREON_URL = "https://www.patreon.com/c/FrozenDice";
 const YOUTUBE_FALLBACK = "https://www.youtube.com/@FrozenDice_no";
@@ -30,6 +32,7 @@ function youtubeChannelUrl(): string {
 type StageRenderContext = {
   scrollYProgress: MotionValue<number>;
   blogPreviews: BlogPreview[];
+  streamSchedule: StreamSchedule | null;
 };
 
 type Stage = {
@@ -79,7 +82,7 @@ const stages: Stage[] = [
     inEnd: 0.8,
     outStart: 0.95,
     outEnd: 1.0,
-    render: () => <Stage4Streams />,
+    render: (ctx) => <Stage4Streams schedule={ctx.streamSchedule} />,
   },
 ];
 
@@ -233,30 +236,139 @@ function BlogPreviewCard({ post }: { post: BlogPreview }) {
   );
 }
 
-function Stage4Streams() {
+function Stage4Streams({ schedule }: { schedule: StreamSchedule | null }) {
+  // Embed channelId from Sanity (editor-controlled) with fallback to the
+  // public env var so the embed still renders if the schedule singleton
+  // hasn't been published yet.
+  const channelId =
+    schedule?.youtubeChannelId ??
+    process.env.NEXT_PUBLIC_YOUTUBE_CHANNEL_ID ??
+    "";
+
   return (
-    <div className="hero-text-outline pointer-events-auto max-w-xl">
-      <p className="mb-3 text-sm font-semibold uppercase tracking-widest text-white/80">
-        Live &amp; on-demand
-      </p>
-      <h2 className="text-4xl font-bold tracking-tight sm:text-5xl">
-        Watch the saga unfold.
-      </h2>
-      <p className="mt-4 text-lg text-white/90">
-        Original campaigns streamed weekly. Catch up on past sessions, or tune
-        in live.
-      </p>
-      <Link
-        href={youtubeChannelUrl()}
-        target="_blank"
-        rel="noopener noreferrer"
-        className={cn(buttonVariants({ size: "lg" }), "mt-8")}
-      >
-        Subscribe on YouTube →
-      </Link>
-      {/* TODO(iteration-4): YouTube embed + LIVE pill + schedule + VOD grid. */}
+    <div className="grid w-full grid-cols-1 items-center gap-12 lg:grid-cols-2">
+      <div className="hero-text-outline pointer-events-auto max-w-xl">
+        <p className="mb-3 text-sm font-semibold uppercase tracking-widest text-white/80">
+          Live &amp; on-demand
+        </p>
+        <h2 className="text-4xl font-bold tracking-tight sm:text-5xl">
+          Watch the saga unfold.
+        </h2>
+        <p className="mt-4 text-lg text-white/90">
+          Original campaigns streamed weekly. Catch up on past sessions, or tune
+          in live.
+        </p>
+        <Link
+          href={youtubeChannelUrl()}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(buttonVariants({ size: "lg" }), "mt-8")}
+        >
+          Subscribe on YouTube →
+        </Link>
+
+        {schedule?.upcoming && schedule.upcoming.length > 0 && (
+          <div className="mt-6 space-y-2">
+            <h3 className="text-xs font-semibold uppercase tracking-widest text-white/80">
+              Upcoming
+            </h3>
+            {schedule.upcoming.slice(0, 2).map((session) => (
+              <div
+                key={session._key}
+                className="rounded-lg border border-white/30 bg-white/10 p-3 backdrop-blur-sm"
+              >
+                <p className="text-sm font-semibold">{session.title}</p>
+                <time
+                  dateTime={session.scheduledAt}
+                  className="text-xs text-white/80"
+                >
+                  {new Date(session.scheduledAt).toLocaleString("en-US", {
+                    weekday: "long",
+                    month: "short",
+                    day: "numeric",
+                    hour: "numeric",
+                    minute: "2-digit",
+                  })}
+                </time>
+              </div>
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div className="pointer-events-auto hidden lg:block">
+        {channelId ? (
+          <YouTubeLiveEmbed channelId={channelId} />
+        ) : (
+          <div className="flex aspect-video w-full items-center justify-center rounded-xl bg-white/10 text-sm text-white/70 backdrop-blur-sm">
+            Stream embed coming soon.
+          </div>
+        )}
+      </div>
     </div>
   );
+}
+
+function YouTubeLiveEmbed({ channelId }: { channelId: string }) {
+  const isLive = useLiveStatus(channelId);
+
+  return (
+    <div className="relative overflow-hidden rounded-xl shadow-2xl">
+      <div className="aspect-video w-full">
+        <iframe
+          src={`https://www.youtube.com/embed/live_stream?channel=${channelId}&autoplay=0&rel=0`}
+          title="FrozenDice live stream"
+          allow="accelerometer; autoplay; clipboard-write; encrypted-media; gyroscope; picture-in-picture"
+          allowFullScreen
+          className="h-full w-full"
+          loading="lazy"
+        />
+      </div>
+      {isLive && (
+        <div
+          aria-label="Live now"
+          className="absolute left-3 top-3 flex items-center gap-2 rounded-full bg-black/70 px-3 py-1 text-sm font-semibold text-white backdrop-blur-sm"
+        >
+          <span className="relative flex h-2.5 w-2.5">
+            <span className="absolute inline-flex h-full w-full animate-ping rounded-full bg-red-500 opacity-75" />
+            <span className="relative inline-flex h-2.5 w-2.5 rounded-full bg-red-500" />
+          </span>
+          LIVE
+        </div>
+      )}
+    </div>
+  );
+}
+
+// Polls /api/youtube/live-status on mount and every 60 seconds. The route
+// itself is cached for 60s, so the actual YouTube API call only fires once
+// per minute per deploy region.
+function useLiveStatus(channelId: string): boolean {
+  const [isLive, setIsLive] = useState(false);
+
+  useEffect(() => {
+    if (!channelId) return;
+    let cancelled = false;
+
+    async function check() {
+      try {
+        const res = await fetch("/api/youtube/live-status");
+        const data = (await res.json()) as { isLive: boolean };
+        if (!cancelled) setIsLive(data.isLive);
+      } catch {
+        // Network error — keep current state, don't surface anything.
+      }
+    }
+
+    check();
+    const interval = setInterval(check, 60_000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [channelId]);
+
+  return isLive;
 }
 
 const PDF_CARDS: {
@@ -333,10 +445,12 @@ function StageOverlay({
   stage,
   scrollYProgress,
   blogPreviews,
+  streamSchedule,
 }: {
   stage: Stage;
   scrollYProgress: MotionValue<number>;
   blogPreviews: BlogPreview[];
+  streamSchedule: StreamSchedule | null;
 }) {
   // Function-form useTransform: every scroll position maps to an explicit
   // return value. Avoids framer-motion's keyframe-interpolation edge cases
@@ -358,7 +472,7 @@ function StageOverlay({
       style={{ opacity }}
       className="absolute inset-0 flex items-center px-6 sm:px-12 lg:px-24"
     >
-      {stage.render({ scrollYProgress, blogPreviews })}
+      {stage.render({ scrollYProgress, blogPreviews, streamSchedule })}
     </motion.div>
   );
 }
@@ -409,10 +523,12 @@ function ReducedMotionStage1() {
 export function HeroCopyOverlay({
   scrollYProgress,
   blogPreviews,
+  streamSchedule,
   reducedMotion = false,
 }: {
   scrollYProgress: MotionValue<number>;
   blogPreviews: BlogPreview[];
+  streamSchedule: StreamSchedule | null;
   reducedMotion?: boolean;
 }) {
   if (reducedMotion) {
@@ -431,6 +547,7 @@ export function HeroCopyOverlay({
           stage={stage}
           scrollYProgress={scrollYProgress}
           blogPreviews={blogPreviews}
+          streamSchedule={streamSchedule}
         />
       ))}
     </div>

--- a/src/components/landing/hero-section.tsx
+++ b/src/components/landing/hero-section.tsx
@@ -4,16 +4,22 @@ import { useEffect, useRef, useState } from "react";
 import { useScroll, useTransform } from "framer-motion";
 import { HeroCanvas } from "./hero-canvas";
 import { HeroCopyOverlay, type BlogPreview } from "./hero-copy-overlay";
+import type { StreamSchedule } from "@/sanity/types";
 
 const TOTAL_FRAMES = 121;
 
 export function HeroSection({
   blogPreviews = [],
+  streamSchedule = null,
 }: {
   // Pre-computed serializable post previews from Sanity, fetched on the
   // server in (marketing)/page.tsx. Empty array is acceptable — Stage 3
   // renders a fallback when no posts are available.
   blogPreviews?: BlogPreview[];
+  // Stream schedule singleton from Sanity. Null if the document hasn't
+  // been published yet — Stage 4 falls back to NEXT_PUBLIC_YOUTUBE_CHANNEL_ID
+  // for the embed in that case.
+  streamSchedule?: StreamSchedule | null;
 }) {
   const heroRef = useRef<HTMLDivElement>(null);
   const [reducedMotion, setReducedMotion] = useState(false);
@@ -45,6 +51,7 @@ export function HeroSection({
           <HeroCopyOverlay
             scrollYProgress={scrollYProgress}
             blogPreviews={blogPreviews}
+            streamSchedule={streamSchedule}
             reducedMotion
           />
         </div>
@@ -72,6 +79,7 @@ export function HeroSection({
         <HeroCopyOverlay
           scrollYProgress={scrollYProgress}
           blogPreviews={blogPreviews}
+          streamSchedule={streamSchedule}
         />
       </div>
     </div>

--- a/src/components/landing/hero-section.tsx
+++ b/src/components/landing/hero-section.tsx
@@ -3,11 +3,18 @@
 import { useEffect, useRef, useState } from "react";
 import { useScroll, useTransform } from "framer-motion";
 import { HeroCanvas } from "./hero-canvas";
-import { HeroCopyOverlay } from "./hero-copy-overlay";
+import { HeroCopyOverlay, type BlogPreview } from "./hero-copy-overlay";
 
 const TOTAL_FRAMES = 121;
 
-export function HeroSection() {
+export function HeroSection({
+  blogPreviews = [],
+}: {
+  // Pre-computed serializable post previews from Sanity, fetched on the
+  // server in (marketing)/page.tsx. Empty array is acceptable — Stage 3
+  // renders a fallback when no posts are available.
+  blogPreviews?: BlogPreview[];
+}) {
   const heroRef = useRef<HTMLDivElement>(null);
   const [reducedMotion, setReducedMotion] = useState(false);
 
@@ -20,7 +27,7 @@ export function HeroSection() {
   }, []);
 
   // Sticky-pinning technique. The outer wrapper creates the scroll space
-  // (1000vh = 4 stages × 250vh). The inner sticky div pins for the duration
+  // (500vh = 4 stages × 125vh). The inner sticky div pins for the duration
   // of the outer's scroll. The dice scrubs in REVERSE (TOTAL_FRAMES → 1) so
   // it starts settled and rolls away across the four stages.
   const { scrollYProgress } = useScroll({
@@ -35,7 +42,11 @@ export function HeroSection() {
       <div ref={heroRef} className="relative">
         <div className="relative h-screen overflow-hidden bg-black">
           <HeroCanvas frameIndex={frameIndex} reducedMotion />
-          <HeroCopyOverlay scrollYProgress={scrollYProgress} reducedMotion />
+          <HeroCopyOverlay
+            scrollYProgress={scrollYProgress}
+            blogPreviews={blogPreviews}
+            reducedMotion
+          />
         </div>
       </div>
     );
@@ -58,7 +69,10 @@ export function HeroSection() {
 
       <div className="sticky top-0 h-screen overflow-hidden bg-black">
         <HeroCanvas frameIndex={frameIndex} />
-        <HeroCopyOverlay scrollYProgress={scrollYProgress} />
+        <HeroCopyOverlay
+          scrollYProgress={scrollYProgress}
+          blogPreviews={blogPreviews}
+        />
       </div>
     </div>
   );

--- a/src/components/site-header.tsx
+++ b/src/components/site-header.tsx
@@ -13,7 +13,7 @@ import {
 } from "@/components/ui/sheet";
 import { cn } from "@/lib/utils";
 
-const PATREON_URL = "https://www.patreon.com/c/FrozenDice";
+const PATREON_URL = "https://www.patreon.com/FrozenDice";
 
 const navLinks = [
   { href: "/blog", label: "Blog" },

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -1,5 +1,11 @@
 import { client } from "./client";
-import type { PostCard, PostDetail, TagRef } from "./types";
+import type {
+  FeaturedVods,
+  PostCard,
+  PostDetail,
+  StreamSchedule,
+  TagRef,
+} from "./types";
 
 const POST_CARD_PROJECTION = `
   _id,
@@ -56,6 +62,40 @@ export async function getAllTags(): Promise<TagRef[]> {
     `*[_type == "tag"] | order(name asc) { _id, name, "slug": slug.current, description }`,
     {},
     { next: { tags: ["tag"] } },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Phase 4: Stream schedule + featured VODs singletons (used by hero stage 4)
+// ---------------------------------------------------------------------------
+
+export async function getStreamSchedule(): Promise<StreamSchedule | null> {
+  return client.fetch(
+    `*[_type == "streamSchedule"][0] {
+      youtubeChannelId,
+      "upcoming": upcoming[] {
+        _key,
+        title,
+        scheduledAt,
+        description
+      }
+    }`,
+    {},
+    { next: { tags: ["streamSchedule"] } },
+  );
+}
+
+export async function getFeaturedVods(): Promise<FeaturedVods | null> {
+  return client.fetch(
+    `*[_type == "featuredVods"][0] {
+      "vods": vods[] {
+        _key,
+        youtubeVideoId,
+        title
+      }
+    }`,
+    {},
+    { next: { tags: ["featuredVods"] } },
   );
 }
 

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -40,3 +40,29 @@ export type PostDetail = PostCard & {
     ogImage?: SanityImage;
   };
 };
+
+// --- Stream schedule singleton ---
+
+export type UpcomingSession = {
+  _key: string;
+  title: string;
+  scheduledAt: string;
+  description?: string;
+};
+
+export type StreamSchedule = {
+  youtubeChannelId: string;
+  upcoming?: UpcomingSession[];
+};
+
+// --- Featured VODs singleton ---
+
+export type Vod = {
+  _key: string;
+  youtubeVideoId: string;
+  title?: string;
+};
+
+export type FeaturedVods = {
+  vods: Vod[];
+};


### PR DESCRIPTION
## Summary

- **Stage 3 (blog):** Server-fetches up to 3 latest posts from Sanity in `(marketing)/page.tsx`. The hero overlay is a Client Component, so the page transforms `PostCard[]` to a serializable `BlogPreview` shape (with pre-built CDN image URLs) before threading through the new `StageRenderContext` to Stage 3's render. Compact preview cards on the right (desktop), each linking to `/blog/[slug]`.
- **Stage 4 (streams):** `youtube.com/embed/live_stream?channel=<id>` embed + LIVE pill that polls `/api/youtube/live-status` (new route handler, 60-second cache). Channel ID resolved from Sanity `streamSchedule.youtubeChannelId` with fallback to `NEXT_PUBLIC_YOUTUBE_CHANNEL_ID`. Up to 2 upcoming sessions from the same singleton render as a glassmorphic schedule strip below the CTA. VOD grid + lightbox deferred to a follow-up.
- **Sanity schema:** new types `StreamSchedule`, `UpcomingSession`, `Vod`, `FeaturedVods`. New queries `getStreamSchedule`, `getFeaturedVods` with tag-based revalidation. Webhook handler is already generic so no edit needed there.
- **Spec doc rewritten:** §3 now describes the actual 4-stage architecture that shipped instead of the original 3-beat hero. Old §3.2–3.4 content is folded into the per-stage descriptions.
- **Patreon URL canonicalized:** `patreon.com/c/FrozenDice` → `patreon.com/FrozenDice` in both header CTA and hero stage 1/2 + reduced-motion paths.

## Test plan

- [ ] Stage 3 (~50–75% scroll): right column shows up to 3 blog post cards with thumbnails + titles + excerpts + dates
- [ ] Click a card → navigates to `/blog/[slug]`
- [ ] Stage 4 (~75–100% scroll): right column shows YouTube live embed of the FrozenDice channel
- [ ] `http://localhost:3000/api/youtube/live-status` returns `{"isLive": false}` (or true if currently live), no 500
- [ ] When channel goes live, the red LIVE pill appears within ~60s
- [ ] Schedule strip on left renders if `streamSchedule.upcoming` has entries
- [ ] Header CTA + hero stage 1 "Become a Patreon" both open `https://www.patreon.com/FrozenDice` in a new tab
- [ ] Reduced-motion path still collapses to stage 1 with direct external CTAs
- [ ] `/blog`, `/store`, `/about` smoke check unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)