### PR TITLE
feat(vods): YouTube Shorts support + seed initial 5 videos

### DIFF
--- a/scripts/seed-featured-vods.ts
+++ b/scripts/seed-featured-vods.ts
@@ -1,0 +1,55 @@
+#!/usr/bin/env -S pnpm tsx
+/**
+ * One-shot: seed the featuredVods singleton with the initial set of 3
+ * regular videos + 2 Shorts. Re-running overwrites the document, so
+ * after the first run prefer editing via Studio.
+ *
+ * Run via:
+ *   set -a && source .env.local && set +a && pnpm tsx scripts/seed-featured-vods.ts
+ */
+import { createClient } from "next-sanity";
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+const token = process.env.SANITY_API_WRITE_TOKEN;
+
+if (!projectId || !dataset || !token) {
+  console.error("Missing env vars");
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId,
+  dataset,
+  apiVersion: "2024-01-01",
+  token,
+  useCdn: false,
+});
+
+const vods = [
+  { youtubeVideoId: "afgfmHpuA4A", isShort: false },
+  { youtubeVideoId: "YU5H6kV4KxE", isShort: false },
+  { youtubeVideoId: "HY170i6JhpM", isShort: false },
+  { youtubeVideoId: "txxi6m3CkjU", isShort: true },
+  { youtubeVideoId: "yvXZ3jVQAk4", isShort: true },
+].map((v, i) => ({
+  _type: "vod",
+  _key: `vod-${i + 1}`,
+  ...v,
+}));
+
+const doc = {
+  _id: "featuredVods",
+  _type: "featuredVods",
+  vods,
+};
+
+async function main() {
+  const result = await client.createOrReplace(doc);
+  console.log("Wrote:", result._id, "vods:", vods.length);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/components/landing/featured-vods-section.tsx
+++ b/src/components/landing/featured-vods-section.tsx
@@ -70,6 +70,11 @@ function VodThumbnail({ vod, onClick }: { vod: Vod; onClick: () => void }) {
           <Play aria-hidden="true" className="h-6 w-6 fill-stone-900 text-stone-900" />
         </div>
       </div>
+      {vod.isShort && (
+        <span className="absolute left-2 top-2 rounded-full bg-black/70 px-2 py-0.5 text-[10px] font-bold uppercase tracking-widest text-white backdrop-blur-sm">
+          Shorts
+        </span>
+      )}
       {vod.title && (
         <div className="absolute inset-x-0 bottom-0 bg-gradient-to-t from-black/80 via-black/40 to-transparent p-3 pt-8">
           <p className="line-clamp-2 text-left text-sm font-medium text-white">
@@ -106,13 +111,20 @@ function VodLightbox({ vod, onClose }: { vod: Vod; onClose: () => void }) {
     };
   }, [onClose]);
 
+  // Shorts are 9:16; constrain to viewport height so a tall short doesn't
+  // overflow on small/short windows. Regular videos stay 16:9 capped at
+  // ~1024px wide.
+  const containerClass = vod.isShort
+    ? "m-auto h-[min(90vh,800px)] aspect-[9/16] rounded-xl bg-black p-0 backdrop:bg-black/80 backdrop:backdrop-blur-sm"
+    : "m-auto w-[min(90vw,1024px)] aspect-video rounded-xl bg-black p-0 backdrop:bg-black/80 backdrop:backdrop-blur-sm";
+
   return (
     <dialog
       ref={dialogRef}
-      className="m-auto w-[min(90vw,1024px)] rounded-xl bg-black p-0 backdrop:bg-black/80 backdrop:backdrop-blur-sm"
+      className={containerClass}
       aria-label={vod.title ? `Playing: ${vod.title}` : "Playing video"}
     >
-      <div className="relative aspect-video w-full">
+      <div className="relative h-full w-full">
         <iframe
           src={`https://www.youtube.com/embed/${vod.youtubeVideoId}?autoplay=1&rel=0`}
           title={vod.title ?? "FrozenDice video"}

--- a/src/sanity/queries.ts
+++ b/src/sanity/queries.ts
@@ -113,7 +113,8 @@ export async function getFeaturedVods(): Promise<FeaturedVods | null> {
       "vods": vods[] {
         _key,
         youtubeVideoId,
-        title
+        title,
+        isShort
       }
     }`,
     {},

--- a/src/sanity/schemas/featuredVods.ts
+++ b/src/sanity/schemas/featuredVods.ts
@@ -28,6 +28,14 @@ export const featuredVods = defineType({
               type: "string",
               description: "Optional. Falls back to the YouTube title.",
             }),
+            defineField({
+              name: "isShort",
+              title: "Is a YouTube Short?",
+              type: "boolean",
+              initialValue: false,
+              description:
+                "When true, the lightbox renders this video at 9:16 (vertical). The grid thumbnail stays 16:9 with a 'Shorts' badge.",
+            }),
           ],
           preview: { select: { title: "title", subtitle: "youtubeVideoId" } },
         }),

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -61,6 +61,7 @@ export type Vod = {
   _key: string;
   youtubeVideoId: string;
   title?: string;
+  isShort?: boolean;
 };
 
 export type FeaturedVods = {


### PR DESCRIPTION
## Summary

- Schema: `Vod` array members get an `isShort` boolean (defaults to false).
- Grid thumbnails stay uniform 16:9 (`mqdefault.jpg`) so the layout doesn't get heterogeneous, but Shorts get a small `SHORTS` badge in the top-left corner.
- Lightbox aspect adapts: 9:16 (capped at `min(90vh, 800px)`) for Shorts, standard 16:9 (capped at `min(90vw, 1024px)`) otherwise.
- Seeded the initial set: 3 regular videos + 2 Shorts (`afgfmHpuA4A`, `YU5H6kV4KxE`, `HY170i6JhpM`, `txxi6m3CkjU`, `yvXZ3jVQAk4`).

## Test plan

- [ ] Open `/` → scroll past the hero → 'Recent episodes' section shows 5 thumbnails (3 regular + 2 with a SHORTS badge)
- [ ] Click a regular thumbnail → lightbox at 16:9, video autoplays
- [ ] Click a Shorts thumbnail → lightbox at 9:16, video autoplays vertically
- [ ] Escape and backdrop click both close
- [ ] In Studio → Featured VODs, the `Is a YouTube Short?` field is visible on each entry; toggling it changes the badge + lightbox aspect after publish

🤖 Generated with [Claude Code](https://claude.com/claude-code)