### PR TITLE
feat(about): rewrite /about as Sanity-sourced RSC (Phase 5)

### DIFF
--- a/scripts/seed-about-page.ts
+++ b/scripts/seed-about-page.ts
@@ -1,0 +1,121 @@
+#!/usr/bin/env -S pnpm tsx
+/**
+ * One-shot: seed (or replace) the aboutPage singleton with a starter draft
+ * grounded in the actual Frozen Dice channel: Nordgaard homebrew world,
+ * biweekly livestreams, weekly Shorts + Dad Jokes + sketches.
+ *
+ * Run via:
+ *   set -a && source .env.local && set +a && pnpm tsx scripts/seed-about-page.ts
+ *
+ * Re-running overwrites the document. After the first run, prefer editing
+ * via Studio. Cast members and the campaign feature are NOT seeded here —
+ * those need real portrait/cover images uploaded via Studio anyway.
+ */
+import { createClient } from "next-sanity";
+
+const projectId = process.env.NEXT_PUBLIC_SANITY_PROJECT_ID;
+const dataset = process.env.NEXT_PUBLIC_SANITY_DATASET;
+const token = process.env.SANITY_API_WRITE_TOKEN;
+
+if (!projectId || !dataset || !token) {
+  console.error(
+    "Missing env: need NEXT_PUBLIC_SANITY_PROJECT_ID, NEXT_PUBLIC_SANITY_DATASET, SANITY_API_WRITE_TOKEN",
+  );
+  process.exit(1);
+}
+
+const client = createClient({
+  projectId,
+  dataset,
+  apiVersion: "2024-01-01",
+  token,
+  useCdn: false,
+});
+
+let blockKeyCounter = 0;
+function block(text: string) {
+  blockKeyCounter += 1;
+  return {
+    _type: "block",
+    _key: `block-${blockKeyCounter}`,
+    style: "normal",
+    markDefs: [],
+    children: [
+      {
+        _type: "span",
+        _key: `span-${blockKeyCounter}`,
+        text,
+        marks: [],
+      },
+    ],
+  };
+}
+
+const storyBody = [
+  block(
+    "Frozen Dice started as a group of friends who couldn't stop talking about Dungeons & Dragons. The kitchen-table sessions turned into a homebrew world, the homebrew world turned into a recurring podcast, and somewhere along the way the camera came on and stayed on.",
+  ),
+  block(
+    "Today we stream biweekly out of Norway, telling stories set in our own continent of Nordgaard — a cold, lore-thick fantasy world shaped by Norse mythology, frostbitten coastlines, and the long winter dark. Between sessions we ship weekly Shorts, dad jokes, and small sketches that keep the lights on between chapters.",
+  ),
+  block(
+    "We're not professional actors. We're nerds who love this game, and we record what would otherwise just be us laughing around a table on a Tuesday night. The audience gets to come along.",
+  ),
+];
+
+const values = [
+  {
+    _type: "value",
+    _key: "value-1",
+    icon: "snowflake",
+    title: "Nordic soul",
+    description:
+      "Our homebrew world Nordgaard pulls from Norse mythology, cold landscapes, and the long dark. The setting matters as much as the dice.",
+  },
+  {
+    _type: "value",
+    _key: "value-2",
+    icon: "dice-5",
+    title: "Story over rules",
+    description:
+      "A dramatic failure beats a safe success. We optimise for the moment, not the math — that's where the saga lives.",
+  },
+  {
+    _type: "value",
+    _key: "value-3",
+    icon: "calendar",
+    title: "Show up every other week",
+    description:
+      "Biweekly livestreams, weekly Shorts, weekly Dad Jokes. Consistency is how a campaign turns into a saga worth following.",
+  },
+  {
+    _type: "value",
+    _key: "value-4",
+    icon: "users",
+    title: "Friends first",
+    description:
+      "We started as friends rolling dice on a kitchen table in Norway. We're still that — the camera just happens to be on.",
+  },
+];
+
+const doc = {
+  _id: "aboutPage",
+  _type: "aboutPage",
+  eyebrow: "About",
+  headline: "The story behind Frozen Dice.",
+  intro:
+    "A Norwegian D&D crew streaming biweekly from our homebrew world of Nordgaard — plus weekly Shorts, dad jokes, and the occasional sketch.",
+  storyBody,
+  values,
+  businessEmail: "hello@frozendice.no",
+};
+
+async function main() {
+  const result = await client.createOrReplace(doc);
+  console.log("Wrote:", result._id);
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/src/app/(marketing)/about/page.tsx
+++ b/src/app/(marketing)/about/page.tsx
@@ -1,120 +1,158 @@
 import type { Metadata } from "next";
-import Link from "next/link";
-import { Dice5, Users, Heart, MapPin } from "lucide-react";
-import { buttonVariants } from "@/components/ui/button";
-import { NewsletterSignup } from "@/components/newsletter-signup";
+import { PortableText } from "@/components/portable-text";
+import { CrewCard } from "@/components/about/crew-card";
+import { CampaignFeature } from "@/components/about/campaign-feature";
+import { ValuesGrid } from "@/components/about/values-grid";
+import { CtaStrip } from "@/components/about/cta-strip";
+import {
+  getAboutPage,
+  getActiveCastMembers,
+  getCurrentCampaign,
+} from "@/sanity/queries-about";
+import { urlForImage } from "@/sanity/image";
+import { siteConfig } from "@/lib/site-config";
 
-export const metadata: Metadata = {
-  title: "About",
-  description:
-    "Frozen Dice is a Norwegian D&D community creating premium tabletop RPG content — battle maps, campaign guides, and digital resources.",
-  alternates: { canonical: "/about" },
-};
+export async function generateMetadata(): Promise<Metadata> {
+  const about = await getAboutPage();
+  if (!about) {
+    return {
+      title: "About",
+      description: "Learn about Frozen Dice.",
+      alternates: { canonical: "/about" },
+    };
+  }
 
-export default function AboutPage() {
+  const title = about.seo?.title ?? about.headline;
+  const description = about.seo?.description ?? about.intro;
+  const ogImage = about.seo?.ogImage
+    ? [
+        {
+          url: urlForImage(about.seo.ogImage)
+            .width(1200)
+            .height(630)
+            .auto("format")
+            .url(),
+          width: 1200,
+          height: 630,
+        },
+      ]
+    : undefined;
+
+  return {
+    title,
+    description,
+    alternates: { canonical: "/about" },
+    openGraph: {
+      type: "website",
+      title,
+      description,
+      url: `${siteConfig.url}/about`,
+      images: ogImage,
+    },
+  };
+}
+
+export default async function AboutPage() {
+  const [about, castMembers, currentCampaign] = await Promise.all([
+    getAboutPage(),
+    getActiveCastMembers(),
+    getCurrentCampaign(),
+  ]);
+
+  if (!about) {
+    return (
+      <div className="mx-auto max-w-2xl px-4 py-32 text-center sm:px-6 lg:px-8">
+        <p className="text-muted-foreground">
+          This page is being set up. Check back soon!
+        </p>
+      </div>
+    );
+  }
+
   return (
     <>
       <section className="py-24 sm:py-32">
         <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
           <div className="mx-auto max-w-2xl text-center">
-            <Dice5 aria-hidden="true" className="mx-auto mb-6 h-16 w-16 text-primary" />
+            {about.eyebrow && (
+              <p className="mb-4 text-sm font-semibold uppercase tracking-widest text-primary">
+                {about.eyebrow}
+              </p>
+            )}
             <h1 className="text-4xl font-bold tracking-tight sm:text-5xl">
-              About Frozen Dice
+              {about.headline}
             </h1>
             <p className="mt-6 text-lg leading-8 text-muted-foreground">
-              A Norwegian community for Dungeons &amp; Dragons enthusiasts,
-              building premium content to make every session unforgettable.
+              {about.intro}
             </p>
           </div>
         </div>
       </section>
 
       <section className="border-t bg-muted/30 py-20 sm:py-28">
-        <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-          <div className="grid gap-12 lg:grid-cols-2 lg:gap-16">
-            <div>
-              <h2 className="text-3xl font-bold tracking-tight">Our Story</h2>
-              <div className="mt-6 space-y-4 text-muted-foreground">
-                <p>
-                  Frozen Dice started as a small group of friends rolling dice
-                  around a kitchen table in Norway. What began as homebrew
-                  campaigns and hand-drawn maps grew into a passion for creating
-                  high-quality tabletop RPG content.
-                </p>
-                <p>
-                  Today we share that passion with the wider D&amp;D community
-                  &mdash; from detailed battle maps to complete campaign
-                  resources, everything we make is designed to save DMs time and
-                  elevate the experience at the table.
-                </p>
-              </div>
-            </div>
-
-            <div className="grid gap-8 sm:grid-cols-2">
-              <div className="space-y-2">
-                <MapPin aria-hidden="true" className="h-8 w-8 text-primary" />
-                <h3 className="font-semibold">Based in Norway</h3>
-                <p className="text-sm text-muted-foreground">
-                  Creating content inspired by Nordic landscapes and mythology.
-                </p>
-              </div>
-              <div className="space-y-2">
-                <Users aria-hidden="true" className="h-8 w-8 text-primary" />
-                <h3 className="font-semibold">Community First</h3>
-                <p className="text-sm text-muted-foreground">
-                  Built by dungeon masters who play every week and know what
-                  tables actually need.
-                </p>
-              </div>
-              <div className="space-y-2">
-                <Heart aria-hidden="true" className="h-8 w-8 text-primary" />
-                <h3 className="font-semibold">Made with Care</h3>
-                <p className="text-sm text-muted-foreground">
-                  Every map, guide, and resource is crafted and playtested before
-                  release.
-                </p>
-              </div>
-              <div className="space-y-2">
-                <Dice5 aria-hidden="true" className="h-8 w-8 text-primary" />
-                <h3 className="font-semibold">Always Rolling</h3>
-                <p className="text-sm text-muted-foreground">
-                  New content every month &mdash; maps, encounters, and campaign
-                  supplements.
-                </p>
-              </div>
-            </div>
+        <div className="mx-auto max-w-3xl px-4 sm:px-6 lg:px-8">
+          <h2 className="mb-8 text-3xl font-bold tracking-tight">Our Story</h2>
+          <div className="prose prose-neutral dark:prose-invert max-w-none">
+            <PortableText value={about.storyBody} />
           </div>
         </div>
       </section>
 
-      <section className="py-20 sm:py-28">
+      {castMembers.length > 0 && (
+        <section className="py-20 sm:py-28">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+            <h2 className="mb-10 text-3xl font-bold tracking-tight">
+              The Crew
+            </h2>
+            <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-3 xl:grid-cols-4">
+              {castMembers.map((member) => (
+                <CrewCard key={member._id} member={member} />
+              ))}
+            </div>
+          </div>
+        </section>
+      )}
+
+      {currentCampaign && (
+        <section className="border-t bg-muted/30 py-20 sm:py-28">
+          <div className="mx-auto max-w-5xl px-4 sm:px-6 lg:px-8">
+            <CampaignFeature campaign={currentCampaign} />
+          </div>
+        </section>
+      )}
+
+      {about.values && about.values.length > 0 && (
+        <section className="py-20 sm:py-28">
+          <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
+            <h2 className="mb-10 text-3xl font-bold tracking-tight">
+              What we stand for
+            </h2>
+            <ValuesGrid values={about.values} />
+          </div>
+        </section>
+      )}
+
+      <section className="border-t py-20 sm:py-28">
         <div className="mx-auto max-w-6xl px-4 sm:px-6 lg:px-8">
-          <div className="mx-auto max-w-xl text-center">
-            <h2 className="text-3xl font-bold tracking-tight">Get Involved</h2>
-            <p className="mt-4 text-muted-foreground">
-              Join our community, browse the store, or subscribe for updates.
+          <CtaStrip />
+        </div>
+      </section>
+
+      {about.businessEmail && (
+        <section className="border-t py-12">
+          <div className="mx-auto max-w-6xl px-4 text-center sm:px-6 lg:px-8">
+            <p className="text-sm text-muted-foreground">
+              Business enquiries:{" "}
+              <a
+                href={`mailto:${about.businessEmail}`}
+                className="underline underline-offset-4 hover:text-foreground"
+              >
+                {about.businessEmail}
+              </a>
             </p>
-            <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
-              <Link
-                href="/store"
-                className={buttonVariants({ size: "lg" })}
-              >
-                Browse the Store
-              </Link>
-              <Link
-                href="/blog"
-                className={buttonVariants({ size: "lg", variant: "outline" })}
-              >
-                Read the Blog
-              </Link>
-            </div>
-            <div className="mt-12">
-              <h3 className="mb-4 text-lg font-semibold">Stay in the Loop</h3>
-              <NewsletterSignup className="mx-auto max-w-md" />
-            </div>
           </div>
-        </div>
-      </section>
+        </section>
+      )}
     </>
   );
 }

--- a/src/components/about/campaign-feature.tsx
+++ b/src/components/about/campaign-feature.tsx
@@ -1,0 +1,65 @@
+import Image from "next/image";
+import Link from "next/link";
+import { ArrowRight } from "lucide-react";
+import { buttonVariants } from "@/components/ui/button";
+import { urlForImage } from "@/sanity/image";
+import type { Campaign } from "@/sanity/types";
+
+export function CampaignFeature({ campaign }: { campaign: Campaign }) {
+  const coverUrl = urlForImage(campaign.coverImage)
+    .width(1200)
+    .height(675)
+    .auto("format")
+    .url();
+
+  const blogTagHref = campaign.blogTag
+    ? `/blog/tag/${campaign.blogTag.slug}`
+    : null;
+
+  return (
+    <div className="overflow-hidden rounded-2xl border bg-muted/30">
+      <div className="relative aspect-video w-full overflow-hidden">
+        <Image
+          src={coverUrl}
+          alt={campaign.coverImage.alt ?? campaign.title}
+          width={1200}
+          height={675}
+          className="h-full w-full object-cover"
+        />
+      </div>
+      <div className="space-y-4 p-6 sm:p-8">
+        <p className="text-sm font-medium uppercase tracking-widest text-primary">
+          Current Campaign
+        </p>
+        <h3 className="text-2xl font-bold tracking-tight sm:text-3xl">
+          {campaign.title}
+        </h3>
+        <p className="max-w-prose text-muted-foreground">{campaign.summary}</p>
+        <div className="flex flex-wrap items-center gap-3">
+          {campaign.youtubePlaylistUrl && (
+            <Link
+              href={campaign.youtubePlaylistUrl}
+              target="_blank"
+              rel="noopener noreferrer"
+              className={buttonVariants({ variant: "default" })}
+            >
+              Watch on YouTube
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          )}
+          {blogTagHref && (
+            <Link
+              href={blogTagHref}
+              className={buttonVariants({
+                variant: campaign.youtubePlaylistUrl ? "outline" : "default",
+              })}
+            >
+              Read session recaps
+              <ArrowRight className="ml-2 h-4 w-4" />
+            </Link>
+          )}
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/about/crew-card.tsx
+++ b/src/components/about/crew-card.tsx
@@ -1,0 +1,52 @@
+import Image from "next/image";
+import { urlForImage } from "@/sanity/image";
+import type { CastMember } from "@/sanity/types";
+
+const roleBadge: Record<string, string> = {
+  dm: "bg-amber-500/15 text-amber-700 dark:text-amber-400",
+  player: "bg-sky-500/15 text-sky-700 dark:text-sky-400",
+};
+
+export function CrewCard({ member }: { member: CastMember }) {
+  const portraitUrl = urlForImage(member.portrait)
+    .width(400)
+    .height(400)
+    .auto("format")
+    .url();
+
+  const hasCharacter = member.characterName || member.characterClass;
+
+  return (
+    <div className="flex flex-col items-center gap-4 rounded-xl border bg-muted/30 p-6 text-center">
+      <div className="relative h-24 w-24 overflow-hidden rounded-full ring-2 ring-border">
+        <Image
+          src={portraitUrl}
+          alt={member.portrait.alt ?? member.name}
+          width={400}
+          height={400}
+          className="h-full w-full object-cover"
+        />
+      </div>
+
+      <div className="space-y-1">
+        <h3 className="text-base font-semibold leading-tight">{member.name}</h3>
+        <span
+          className={`inline-block rounded-full px-2 py-0.5 text-xs font-medium uppercase tracking-wide ${
+            roleBadge[member.role] ?? roleBadge.player
+          }`}
+        >
+          {member.role === "dm" ? "Dungeon Master" : "Player"}
+        </span>
+        {hasCharacter && (
+          <p className="text-sm text-muted-foreground">
+            {member.characterName}
+            {member.characterName && member.characterClass && " · "}
+            {member.characterClass}
+          </p>
+        )}
+      </div>
+
+      <p className="text-sm leading-relaxed text-muted-foreground">{member.bio}</p>
+    </div>
+  );
+}

--- a/src/components/about/cta-strip.tsx
+++ b/src/components/about/cta-strip.tsx
@@ -1,0 +1,41 @@
+import Link from "next/link";
+import { buttonVariants } from "@/components/ui/button";
+import { cn } from "@/lib/utils";
+
+export function CtaStrip() {
+  return (
+    <div className="rounded-2xl bg-primary/5 px-6 py-12 text-center sm:px-12">
+      <h2 className="text-2xl font-bold tracking-tight sm:text-3xl">
+        Join the saga
+      </h2>
+      <p className="mt-4 text-muted-foreground">
+        Support the show on Patreon, tune in live, or grab something from the
+        shop.
+      </p>
+      <div className="mt-8 flex flex-col items-center justify-center gap-4 sm:flex-row">
+        <a
+          href="https://www.patreon.com/FrozenDice"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={cn(buttonVariants({ size: "lg" }), "gap-2")}
+        >
+          Become a Patreon
+        </a>
+        <a
+          href="https://www.youtube.com/@FrozenDice_no"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={buttonVariants({ size: "lg", variant: "outline" })}
+        >
+          Watch Live
+        </a>
+        <Link
+          href="/store"
+          className={buttonVariants({ size: "lg", variant: "outline" })}
+        >
+          Shop
+        </Link>
+      </div>
+    </div>
+  );
+}

--- a/src/components/about/values-grid.tsx
+++ b/src/components/about/values-grid.tsx
@@ -1,0 +1,26 @@
+import type { LucideIcon } from "lucide-react";
+import { getLucideIcon } from "@/lib/lucide-icon";
+import type { AboutValue } from "@/sanity/types";
+
+async function ValuePillar({ value }: { value: AboutValue }) {
+  const Icon: LucideIcon = await getLucideIcon(value.icon);
+  return (
+    <div className="space-y-3 rounded-xl border bg-muted/30 p-6">
+      <Icon aria-hidden="true" className="h-8 w-8 text-primary" />
+      <h3 className="font-semibold">{value.title}</h3>
+      <p className="text-sm leading-relaxed text-muted-foreground">
+        {value.description}
+      </p>
+    </div>
+  );
+}
+
+export async function ValuesGrid({ values }: { values: AboutValue[] }) {
+  return (
+    <div className="grid gap-6 sm:grid-cols-2 lg:grid-cols-4">
+      {values.map((v) => (
+        <ValuePillar key={v._key} value={v} />
+      ))}
+    </div>
+  );
+}

--- a/src/lib/lucide-icon.ts
+++ b/src/lib/lucide-icon.ts
@@ -1,0 +1,19 @@
+import type { LucideIcon } from "lucide-react";
+
+function toPascalCase(kebab: string): string {
+  return kebab
+    .split("-")
+    .filter(Boolean)
+    .map((seg) => seg.charAt(0).toUpperCase() + seg.slice(1))
+    .join("");
+}
+
+export async function getLucideIcon(kebabName: string | undefined): Promise<LucideIcon> {
+  const pascalName = toPascalCase(kebabName ?? "sparkles");
+  const icons = (await import("lucide-react")) as Record<string, unknown>;
+  const candidate = icons[pascalName];
+  if (typeof candidate === "function" || typeof candidate === "object") {
+    return candidate as LucideIcon;
+  }
+  return icons.Sparkles as LucideIcon;
+}

--- a/src/sanity/queries-about.ts
+++ b/src/sanity/queries-about.ts
@@ -1,0 +1,60 @@
+import { client } from "./client";
+import type { AboutPage, Campaign, CastMember } from "./types";
+
+export async function getAboutPage(): Promise<AboutPage | null> {
+  return client.fetch(
+    `*[_type == "aboutPage"][0] {
+      "eyebrow": coalesce(eyebrow, "About"),
+      headline,
+      intro,
+      storyBody,
+      values[] {
+        _key,
+        icon,
+        title,
+        description
+      },
+      businessEmail,
+      seo
+    }`,
+    {},
+    { next: { tags: ["aboutPage"] } },
+  );
+}
+
+export async function getActiveCastMembers(): Promise<CastMember[]> {
+  return client.fetch(
+    `*[_type == "castMember" && isActive == true] | order(order asc) {
+      _id,
+      name,
+      role,
+      portrait { ..., "alt": coalesce(alt, "") },
+      characterName,
+      characterClass,
+      bio,
+      isActive,
+      order
+    }`,
+    {},
+    { next: { tags: ["castMember"] } },
+  );
+}
+
+export async function getCurrentCampaign(): Promise<Campaign | null> {
+  return client.fetch(
+    `*[_type == "campaign" && status == "current"] | order(_createdAt asc) [0] {
+      _id,
+      title,
+      "slug": slug.current,
+      summary,
+      status,
+      coverImage { ..., "alt": coalesce(alt, "") },
+      startDate,
+      endDate,
+      youtubePlaylistUrl,
+      "blogTag": blogTag->{ _id, name, "slug": slug.current }
+    }`,
+    {},
+    { next: { tags: ["campaign"] } },
+  );
+}

--- a/src/sanity/types.ts
+++ b/src/sanity/types.ts
@@ -86,3 +86,59 @@ export type PrivacyPolicy = {
   dataControllerAddress?: string;
   contactEmail?: string;
 };
+
+// --- About page ---
+
+export type AboutValue = {
+  _key: string;
+  icon: string;
+  title: string;
+  description: string;
+};
+
+export type AboutPageSeo = {
+  title?: string;
+  description?: string;
+  ogImage?: SanityImage;
+};
+
+export type AboutPage = {
+  eyebrow: string;
+  headline: string;
+  intro: string;
+  storyBody: PortableTextBlock[];
+  values: AboutValue[];
+  businessEmail: string;
+  seo?: AboutPageSeo;
+};
+
+export type CastMember = {
+  _id: string;
+  name: string;
+  role: "dm" | "player";
+  portrait: SanityImage;
+  characterName?: string;
+  characterClass?: string;
+  bio: string;
+  isActive: boolean;
+  order: number;
+};
+
+export type CampaignBlogTag = {
+  _id: string;
+  name: string;
+  slug: string;
+};
+
+export type Campaign = {
+  _id: string;
+  title: string;
+  slug: string;
+  summary: string;
+  status: "current" | "upcoming" | "past";
+  coverImage: SanityImage;
+  startDate?: string;
+  endDate?: string;
+  youtubePlaylistUrl?: string;
+  blogTag?: CampaignBlogTag;
+};


### PR DESCRIPTION
## Summary

- Replaces the placeholder \`/about\` (hardcoded copy + \`NewsletterSignup\` + four generic icon pillars) with a 7-section CMS-driven layout sourced from the existing \`aboutPage\` / \`castMember\` / \`campaign\` Sanity schemas (Phase 1).
- Sections: Hero, Our Story (PortableText), The Crew (active members only, ordered), Current Campaign (rendered only when \`status == \"current\"\`), Values pillars (dynamic Lucide icons), CTA strip (Patreon / Watch Live / Shop — corrected URLs and \"Become a Patreon\" copy), Contact \`mailto:\`.
- Adds \`scripts/seed-about-page.ts\` with starter copy grounded in real channel context: Nordgaard homebrew world, biweekly livestream cadence, weekly Shorts + Dad Jokes + sketches. Already executed against the dataset.
- \`generateMetadata\` reads from the live \`aboutPage\` document; OG image resolves via \`urlForImage(...).width(1200).height(630)\` when the optional \`seo.ogImage\` is set.
- \`NewsletterSignup\` is no longer imported on the page; the component file stays in the repo until Phase 6 cleanup.

## Plan deviations

- **Skipped Task 3 (revalidate tag map)** — \`/api/revalidate\` is generic; calls \`revalidateTag(body._type)\` for any type, so \`aboutPage\` / \`castMember\` / \`campaign\` already work without changes.
- **Skipped Task 12 (sitemap entry)** — \`/about\` is already in \`sitemap.ts\`.
- **CtaStrip URL/copy fixes vs. plan**: Patreon \`/c/FrozenDice\` → \`/FrozenDice\`, \"Become a Patron\" → \"Become a Patreon\", YouTube \`@frozendice\` → \`@FrozenDice_no\` — matches the corrections from Phase 4.
- **Simplified \`generateMetadata\`** — the plan's \`ogImage\` block was a no-op; resolved properly via \`urlForImage\` when \`seo.ogImage\` is set, otherwise falls through to layout-level defaults.

## Pending content (user-authored via Studio)

The page renders gracefully when Crew / Campaign are empty; both sections are conditional on data presence.

- [ ] Add 3-4 \`castMember\` documents in Studio with portraits (real names + character names + bio)
- [ ] Add the current \`campaign\` document (\"Age of Exploration\" appears to be the current arc per the YouTube channel) with a cover image and YouTube playlist URL
- [ ] Optional: refine the seeded \`aboutPage\` story copy and contact email via Studio

## Test plan

- [x] \`pnpm tsc --noEmit\` clean
- [x] \`pnpm build\` clean; \`/about\` builds as a server-rendered route
- [x] \`scripts/seed-about-page.ts\` executed; singleton populated
- [ ] Smoke test \`/about\` in the browser after merging (verify Hero + Our Story + Values + CTA strip + Contact render; Crew and Campaign sections gracefully absent until Studio content is added)
- [ ] Verify Studio publish on \`aboutPage\` triggers revalidation

🤖 Generated with [Claude Code](https://claude.com/claude-code)